### PR TITLE
Add Windows daemon transport and improve CLI fallback behavior

### DIFF
--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -123,9 +123,13 @@ impl CdpClient {
                     }
                     // Send the handle command but don't wait for its response here
                     // (we are still waiting for the original 'id')
-                    self.send_raw_no_wait(session_id, "Page.handleJavaScriptDialog", handler_params)
-                        .await
-                        .map_err(|e| anyhow!("Failed to send dialog handle command: {e}"))?;
+                    self.send_raw_no_wait(
+                        session_id,
+                        "Page.handleJavaScriptDialog",
+                        handler_params,
+                    )
+                    .await
+                    .map_err(|e| anyhow!("Failed to send dialog handle command: {e}"))?;
                     continue;
                 } else {
                     bail!("A javascript dialog is open ({dialog_type}: {msg}). Use `evaluate` with --dialog-action to dismiss it.");

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 #[cfg(windows)]
 use tokio::net::TcpStream;
 #[cfg(unix)]
@@ -33,18 +33,23 @@ pub async fn send_to_daemon(request: &DaemonRequest) -> Result<DaemonResponse> {
 /// Spawn the daemon process in the background.
 pub fn spawn_daemon(ws_url: &str) -> Result<()> {
     let exe = std::env::current_exe()?;
-    std::process::Command::new(&exe)
-        .args(["__daemon__", ws_url])
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.args(["__daemon__", ws_url])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()?;
+        .stderr(std::process::Stdio::null());
+
+    #[cfg(windows)]
+    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+
+    cmd.spawn()?;
     Ok(())
 }
 
-/// Wait for the daemon socket to become available.
+/// Wait for the daemon socket to become available, with exponential backoff.
 pub async fn wait_for_daemon() -> Result<()> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let mut delay = Duration::from_millis(50);
     loop {
         if tokio::time::Instant::now() > deadline {
             bail!("Daemon failed to start within 5 seconds");
@@ -52,6 +57,12 @@ pub async fn wait_for_daemon() -> Result<()> {
         if connect_daemon().await.is_ok() {
             return Ok(());
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Simple jitter based on current time subseconds
+        let jitter = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| Duration::from_millis(d.subsec_nanos() as u64 % (delay.as_millis() as u64 + 1)))
+            .unwrap_or_default();
+        tokio::time::sleep(delay + jitter).await;
+        delay = (delay * 2).min(Duration::from_millis(500));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,13 +1,26 @@
 use anyhow::{bail, Result};
 use std::time::Duration;
+#[cfg(windows)]
+use tokio::net::TcpStream;
+#[cfg(unix)]
 use tokio::net::UnixStream;
 
 use crate::protocol::*;
 
+#[cfg(unix)]
+async fn connect_daemon() -> Result<UnixStream> {
+    Ok(UnixStream::connect(socket_path()).await?)
+}
+
+#[cfg(windows)]
+async fn connect_daemon() -> Result<TcpStream> {
+    let addr = std::fs::read_to_string(addr_path())?;
+    Ok(TcpStream::connect(addr.trim()).await?)
+}
+
 /// Try to send a request to the daemon. Returns error if daemon is not running.
 pub async fn send_to_daemon(request: &DaemonRequest) -> Result<DaemonResponse> {
-    let sock = socket_path();
-    let mut stream = UnixStream::connect(&sock).await?;
+    let mut stream = connect_daemon().await?;
 
     let req_bytes = serde_json::to_vec(request)?;
     write_msg(&mut stream, &req_bytes).await?;
@@ -36,7 +49,7 @@ pub async fn wait_for_daemon() -> Result<()> {
         if tokio::time::Instant::now() > deadline {
             bail!("Daemon failed to start within 5 seconds");
         }
-        if UnixStream::connect(socket_path()).await.is_ok() {
+        if connect_daemon().await.is_ok() {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -14,6 +14,36 @@ use serde_json::json;
 
 const IDLE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
+/// Result of handling a single daemon connection.
+enum ConnectionOutcome {
+    /// Continue accepting new connections.
+    Continue,
+    /// Fatal error occurred; daemon should exit.
+    Fatal,
+}
+
+macro_rules! run_accept_loop_body {
+    ($accept:expr, $client:expr, $ws_url:expr) => {
+        loop {
+            let accept = tokio::time::timeout(IDLE_TIMEOUT, $accept).await;
+
+            match accept {
+                Ok(Ok((stream, _))) => match handle_connection(stream, $client, $ws_url).await {
+                    ConnectionOutcome::Continue => {}
+                    ConnectionOutcome::Fatal => break,
+                },
+                Ok(Err(e)) => {
+                    eprintln!("daemon: accept error: {e}");
+                }
+                Err(_) => {
+                    // Idle timeout — exit
+                    break;
+                }
+            }
+        }
+    };
+}
+
 pub async fn run_daemon(ws_url: &str) -> Result<()> {
     // Write PID
     std::fs::write(pid_path(), std::process::id().to_string())?;
@@ -49,7 +79,7 @@ pub async fn run_daemon(ws_url: &str) -> Result<()> {
     let mut client: Option<CdpClient> = None;
 
     // Signal readiness by socket/address existence (it's already bound)
-    run_accept_loop(listener, &mut client, ws_url).await;
+    run_accept_loop_body!(listener.accept(), &mut client, ws_url);
 
     #[cfg(unix)]
     let _ = std::fs::remove_file(socket_path());
@@ -61,51 +91,7 @@ pub async fn run_daemon(ws_url: &str) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
-async fn run_accept_loop(listener: UnixListener, client: &mut Option<CdpClient>, ws_url: &str) {
-    loop {
-        let accept = tokio::time::timeout(IDLE_TIMEOUT, listener.accept()).await;
-
-        match accept {
-            Ok(Ok((stream, _))) => {
-                if !handle_connection(stream, client, ws_url).await {
-                    break;
-                }
-            }
-            Ok(Err(e)) => {
-                eprintln!("daemon: accept error: {e}");
-            }
-            Err(_) => {
-                // Idle timeout — exit
-                break;
-            }
-        }
-    }
-}
-
-#[cfg(windows)]
-async fn run_accept_loop(listener: TcpListener, client: &mut Option<CdpClient>, ws_url: &str) {
-    loop {
-        let accept = tokio::time::timeout(IDLE_TIMEOUT, listener.accept()).await;
-
-        match accept {
-            Ok(Ok((stream, _))) => {
-                if !handle_connection(stream, client, ws_url).await {
-                    break;
-                }
-            }
-            Ok(Err(e)) => {
-                eprintln!("daemon: accept error: {e}");
-            }
-            Err(_) => {
-                // Idle timeout — exit
-                break;
-            }
-        }
-    }
-}
-
-async fn handle_connection<S>(mut stream: S, client: &mut Option<CdpClient>, ws_url: &str) -> bool
+async fn handle_connection<S>(mut stream: S, client: &mut Option<CdpClient>, ws_url: &str) -> ConnectionOutcome
 where
     S: AsyncReadExt + AsyncWriteExt + Unpin,
 {
@@ -113,7 +99,7 @@ where
         Ok(b) => b,
         Err(e) => {
             eprintln!("daemon: read error: {e}");
-            return true;
+            return ConnectionOutcome::Continue;
         }
     };
 
@@ -126,7 +112,7 @@ where
                 error: format!("Invalid request: {e}"),
             };
             let _ = write_msg(&mut stream, &serde_json::to_vec(&resp).unwrap()).await;
-            return true;
+            return ConnectionOutcome::Continue;
         }
     };
 
@@ -142,12 +128,19 @@ where
                 };
                 let _ = write_msg(&mut stream, &serde_json::to_vec(&resp).unwrap()).await;
                 // Exit daemon if we can't connect, so the next CLI call will spawn a fresh daemon
-                return false;
+                return ConnectionOutcome::Fatal;
             }
         }
     }
 
-    let response = handle_request(client.as_mut().unwrap(), &request).await;
+    let response = match client.as_mut() {
+        Some(client) => handle_request(client, &request).await,
+        None => DaemonResponse {
+            success: false,
+            output: String::new(),
+            error: String::from("Failed to connect to Chrome: client initialization failed"),
+        },
+    };
 
     // Check if the error indicates a disconnected WebSocket.
     // If so, we should exit the daemon so it can be respawned cleanly next time.
@@ -160,7 +153,11 @@ where
         let _ = write_msg(&mut stream, &resp_bytes).await;
     }
 
-    !is_fatal
+    if is_fatal {
+        ConnectionOutcome::Fatal
+    } else {
+        ConnectionOutcome::Continue
+    }
 }
 
 async fn handle_request(client: &mut CdpClient, req: &DaemonRequest) -> DaemonResponse {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, Result};
 use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+#[cfg(windows)]
+use tokio::net::TcpListener;
+#[cfg(unix)]
 use tokio::net::UnixListener;
 
 use crate::cdp::CdpClient;
@@ -11,82 +15,60 @@ use serde_json::json;
 const IDLE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
 pub async fn run_daemon(ws_url: &str) -> Result<()> {
-    // Clean up stale socket
-    let sock = socket_path();
-    let _ = std::fs::remove_file(&sock);
-
     // Write PID
     std::fs::write(pid_path(), std::process::id().to_string())?;
 
-    // Bind socket FIRST so the CLI knows the daemon is alive and can connect.
-    // If we wait for CdpClient::connect first, a macOS network permission prompt
-    // can block the daemon and cause the CLI's 5-second wait_for_daemon timeout to expire.
-    let listener = UnixListener::bind(&sock)?;
+    #[cfg(unix)]
+    let listener = {
+        // Clean up stale socket
+        let sock = socket_path();
+        let _ = std::fs::remove_file(&sock);
+
+        // Bind socket FIRST so the CLI knows the daemon is alive and can connect.
+        // If we wait for CdpClient::connect first, a macOS network permission prompt
+        // can block the daemon and cause the CLI's 5-second wait_for_daemon timeout to expire.
+        UnixListener::bind(&sock)?
+    };
+
+    #[cfg(windows)]
+    let listener = {
+        // Clean up stale address file
+        let _ = std::fs::remove_file(addr_path());
+
+        // Bind listener FIRST so the CLI knows the daemon is alive and can connect.
+        // If we wait for CdpClient::connect first, a Chrome/network permission prompt
+        // can block the daemon and cause the CLI's 5-second wait_for_daemon timeout to expire.
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        std::fs::write(addr_path(), listener.local_addr()?.to_string())?;
+        listener
+    };
 
     // We don't connect immediately. We wait for the first connection from the CLI.
     // This ensures the CLI wait_for_daemon() succeeds, and the CLI blocks on read_msg()
     // while the daemon handles the potentially slow macOS/Chrome network permission prompt.
     let mut client: Option<CdpClient> = None;
 
-    // Signal readiness by socket existence (it's already bound)
+    // Signal readiness by socket/address existence (it's already bound)
+    run_accept_loop(listener, &mut client, ws_url).await;
+
+    #[cfg(unix)]
+    let _ = std::fs::remove_file(socket_path());
+
+    #[cfg(windows)]
+    let _ = std::fs::remove_file(addr_path());
+
+    let _ = std::fs::remove_file(pid_path());
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn run_accept_loop(listener: UnixListener, client: &mut Option<CdpClient>, ws_url: &str) {
     loop {
         let accept = tokio::time::timeout(IDLE_TIMEOUT, listener.accept()).await;
 
         match accept {
-            Ok(Ok((mut stream, _))) => {
-                let req_bytes = match read_msg(&mut stream).await {
-                    Ok(b) => b,
-                    Err(e) => {
-                        eprintln!("daemon: read error: {e}");
-                        continue;
-                    }
-                };
-
-                let request: DaemonRequest = match serde_json::from_slice(&req_bytes) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        let resp = DaemonResponse {
-                            success: false,
-                            output: String::new(),
-                            error: format!("Invalid request: {e}"),
-                        };
-                        let _ = write_msg(&mut stream, &serde_json::to_vec(&resp).unwrap()).await;
-                        continue;
-                    }
-                };
-
-                // Connect lazily
-                if client.is_none() {
-                    match CdpClient::connect(ws_url).await {
-                        Ok(c) => client = Some(c),
-                        Err(e) => {
-                            let resp = DaemonResponse {
-                                success: false,
-                                output: String::new(),
-                                error: format!("Failed to connect to Chrome: {e:#}"),
-                            };
-                            let _ = write_msg(&mut stream, &serde_json::to_vec(&resp).unwrap()).await;
-                            // Exit daemon if we can't connect, so the next CLI call will spawn a fresh daemon
-                            break;
-                        }
-                    }
-                }
-
-                let response = handle_request(client.as_mut().unwrap(), &request).await;
-
-                // Check if the error indicates a disconnected WebSocket.
-                // If so, we should exit the daemon so it can be respawned cleanly next time.
-                let is_fatal = !response.success && (
-                    response.error.contains("WebSocket closed") || 
-                    response.error.contains("WebSocket connection closed") ||
-                    response.error.contains("WebSocket error")
-                );
-
-                if let Ok(resp_bytes) = serde_json::to_vec(&response) {
-                    let _ = write_msg(&mut stream, &resp_bytes).await;
-                }
-
-                if is_fatal {
+            Ok(Ok((stream, _))) => {
+                if !handle_connection(stream, client, ws_url).await {
                     break;
                 }
             }
@@ -99,10 +81,86 @@ pub async fn run_daemon(ws_url: &str) -> Result<()> {
             }
         }
     }
+}
 
-    let _ = std::fs::remove_file(&sock);
-    let _ = std::fs::remove_file(pid_path());
-    Ok(())
+#[cfg(windows)]
+async fn run_accept_loop(listener: TcpListener, client: &mut Option<CdpClient>, ws_url: &str) {
+    loop {
+        let accept = tokio::time::timeout(IDLE_TIMEOUT, listener.accept()).await;
+
+        match accept {
+            Ok(Ok((stream, _))) => {
+                if !handle_connection(stream, client, ws_url).await {
+                    break;
+                }
+            }
+            Ok(Err(e)) => {
+                eprintln!("daemon: accept error: {e}");
+            }
+            Err(_) => {
+                // Idle timeout — exit
+                break;
+            }
+        }
+    }
+}
+
+async fn handle_connection<S>(mut stream: S, client: &mut Option<CdpClient>, ws_url: &str) -> bool
+where
+    S: AsyncReadExt + AsyncWriteExt + Unpin,
+{
+    let req_bytes = match read_msg(&mut stream).await {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("daemon: read error: {e}");
+            return true;
+        }
+    };
+
+    let request: DaemonRequest = match serde_json::from_slice(&req_bytes) {
+        Ok(r) => r,
+        Err(e) => {
+            let resp = DaemonResponse {
+                success: false,
+                output: String::new(),
+                error: format!("Invalid request: {e}"),
+            };
+            let _ = write_msg(&mut stream, &serde_json::to_vec(&resp).unwrap()).await;
+            return true;
+        }
+    };
+
+    // Connect lazily
+    if client.is_none() {
+        match CdpClient::connect(ws_url).await {
+            Ok(c) => *client = Some(c),
+            Err(e) => {
+                let resp = DaemonResponse {
+                    success: false,
+                    output: String::new(),
+                    error: format!("Failed to connect to Chrome: {e:#}"),
+                };
+                let _ = write_msg(&mut stream, &serde_json::to_vec(&resp).unwrap()).await;
+                // Exit daemon if we can't connect, so the next CLI call will spawn a fresh daemon
+                return false;
+            }
+        }
+    }
+
+    let response = handle_request(client.as_mut().unwrap(), &request).await;
+
+    // Check if the error indicates a disconnected WebSocket.
+    // If so, we should exit the daemon so it can be respawned cleanly next time.
+    let is_fatal = !response.success
+        && (response.error.contains("WebSocket closed")
+            || response.error.contains("WebSocket connection closed")
+            || response.error.contains("WebSocket error"));
+
+    if let Ok(resp_bytes) = serde_json::to_vec(&response) {
+        let _ = write_msg(&mut stream, &resp_bytes).await;
+    }
+
+    !is_fatal
 }
 
 async fn handle_request(client: &mut CdpClient, req: &DaemonRequest) -> DaemonResponse {
@@ -188,13 +246,7 @@ async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Result<
             let expr = args["expression"]
                 .as_str()
                 .ok_or(anyhow!("expression required"))?;
-            commands::evaluate::evaluate(
-                client,
-                &session_id,
-                expr,
-                req.json_output,
-            )
-            .await
+            commands::evaluate::evaluate(client, &session_id, expr, req.json_output).await
         }
         "click" => {
             let sel = args["selector"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,15 +283,7 @@ async fn run() -> Result<()> {
     // Daemon not running — spawn it
     client::spawn_daemon(&ws_url)?;
     if let Err(e) = client::wait_for_daemon().await {
-        eprintln!("Warning: daemon unavailable ({e}), running directly");
-        let output = run_direct(&cli, &ws_url).await?;
-        if !output.is_empty() {
-            print!("{}", output);
-            if !output.ends_with('\n') {
-                println!();
-            }
-        }
-        return Ok(());
+        return run_direct_fallback(&cli, &ws_url, &e).await;
     }
 
     // Retry via daemon
@@ -302,17 +294,22 @@ async fn run() -> Result<()> {
         }
         Err(e) => {
             // Daemon failed — fall back to direct execution
-            eprintln!("Warning: daemon unavailable ({e}), running directly");
-            let output = run_direct(&cli, &ws_url).await?;
-            if !output.is_empty() {
-                print!("{}", output);
-                if !output.ends_with('\n') {
-                    println!();
-                }
-            }
-            Ok(())
+            run_direct_fallback(&cli, &ws_url, &e).await
         }
     }
+}
+
+/// Fall back to direct execution when the daemon is unavailable.
+async fn run_direct_fallback(cli: &Cli, ws_url: &str, error: &anyhow::Error) -> Result<()> {
+    eprintln!("Warning: daemon unavailable ({error}), running directly");
+    let output = run_direct(cli, ws_url).await?;
+    if !output.is_empty() {
+        print!("{output}");
+        if !output.ends_with('\n') {
+            println!();
+        }
+    }
+    Ok(())
 }
 
 /// Direct execution without daemon (fallback).
@@ -348,9 +345,13 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<String> {
         .send_to_target(&session_id, "Page.enable", json!({}))
         .await;
 
-    if let Commands::Evaluate { dialog_action, .. } = &cli.command {
-        client.dialog_action = dialog_action.clone();
-    }
+    // Extract dialog_action if set (only available on Evaluate command, but
+    // apply it for all commands in direct mode to match daemon behavior)
+    let dialog_action = match &cli.command {
+        Commands::Evaluate { dialog_action, .. } => dialog_action.clone(),
+        _ => None,
+    };
+    client.dialog_action = dialog_action;
 
     let result = match &cli.command {
         Commands::Navigate {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,11 @@ use serde_json::json;
 use protocol::DaemonRequest;
 
 #[derive(Parser)]
-#[command(name = "chrome-devtools", version, about = "Chrome DevTools Protocol CLI")]
+#[command(
+    name = "chrome-devtools",
+    version,
+    about = "Chrome DevTools Protocol CLI"
+)]
 struct Cli {
     /// Explicit WebSocket endpoint (skips auto-connect)
     #[arg(long, global = true, env = "CHROME_WS_ENDPOINT")]
@@ -248,14 +252,16 @@ async fn run() -> Result<()> {
     let cli = match Cli::try_parse() {
         Ok(c) => c,
         Err(e) => {
+            if matches!(e.kind(), ErrorKind::DisplayHelp | ErrorKind::DisplayVersion) {
+                e.exit();
+            }
+
             let err_str = e.render().to_string();
             let clean_err = err_str.replace("For more information, try '--help'.", "");
             eprintln!("{}", clean_err.trim_end());
-            if e.kind() != ErrorKind::DisplayHelp && e.kind() != ErrorKind::DisplayVersion {
-                println!();
-                let mut cmd = Cli::command();
-                let _ = cmd.print_help();
-            }
+            println!();
+            let mut cmd = Cli::command();
+            let _ = cmd.print_help();
             std::process::exit(1);
         }
     };
@@ -276,7 +282,17 @@ async fn run() -> Result<()> {
 
     // Daemon not running — spawn it
     client::spawn_daemon(&ws_url)?;
-    client::wait_for_daemon().await?;
+    if let Err(e) = client::wait_for_daemon().await {
+        eprintln!("Warning: daemon unavailable ({e}), running directly");
+        let output = run_direct(&cli, &ws_url).await?;
+        if !output.is_empty() {
+            print!("{}", output);
+            if !output.ends_with('\n') {
+                println!();
+            }
+        }
+        return Ok(());
+    }
 
     // Retry via daemon
     match client::send_to_daemon(&request).await {
@@ -367,17 +383,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<String> {
             )
             .await
         }
-        Commands::Evaluate {
-            expression,
-            ..
-        } => {
-            commands::evaluate::evaluate(
-                &mut client,
-                &session_id,
-                expression,
-                cli.json,
-            )
-            .await
+        Commands::Evaluate { expression, .. } => {
+            commands::evaluate::evaluate(&mut client, &session_id, expression, cli.json).await
         }
         Commands::Click { selector } => {
             commands::input::click(&mut client, &session_id, selector).await

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -21,8 +21,14 @@ pub struct DaemonResponse {
     pub error: String,
 }
 
+#[cfg(unix)]
 pub fn socket_path() -> PathBuf {
     std::env::temp_dir().join("chrome-devtools-daemon.sock")
+}
+
+#[cfg(windows)]
+pub fn addr_path() -> PathBuf {
+    std::env::temp_dir().join("chrome-devtools-daemon.addr")
 }
 
 pub fn pid_path() -> PathBuf {


### PR DESCRIPTION
Hi, I fixed the Windows compile error related to #1 and made a few small reliability improvements with help from Codex.

## What changed

- Added Windows daemon IPC support using loopback TCP and a temporary address file.
- Kept Unix platforms on Unix domain sockets.
- Shared daemon connection handling across platforms for request parsing, lazy CDP connection, response writing, and fatal WebSocket handling.
- Fixed `--help` and `--version` so they return a successful exit code.
- Added direct CDP fallback when daemon startup is delayed or unavailable.
- Applied `rustfmt` to the dialog handler call site.

## Why

The previous daemon implementation used Unix socket APIs directly, which caused Windows builds to fail. This PR adds a Windows-compatible transport while preserving the existing Unix behavior.

It also fixes two small CLI reliability issues: help/version output now exits successfully, and commands can fall back to direct CDP execution when the daemon is unavailable.

## Test environment

- OS: Windows 10
- Rust toolchain: stable-x86_64-pc-windows-msvc
- rustc: 1.95.0
- cargo: 1.95.0
- Browser: Google Chrome 148.0.7778.96

## Testing

- `cargo fmt --check`
- `cargo check`
- Manual Chrome command testing on Windows:
  - `list-pages`
  - `evaluate`
  - `wait-for`
  - `resize`
  - `fill`
  - `click`
  - `hover`
  - `screenshot`
  - `list3p-tools`
  - `execute3p-tool`
