### PR TITLE
fix: compile error on Windows

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,6 @@
 use anyhow::{bail, Result};
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
 use std::time::{Duration, SystemTime};
 #[cfg(windows)]
 use tokio::net::TcpStream;


### PR DESCRIPTION
Hi aeroxy, me again! Haha.

I noticed a compilation error on Windows and fixed it by conditionally importing CommandExt only for the Windows platform.

Changes:

- Added #[cfg(windows)] attribute to guard the Windows-specific process extension.

Error:

<img width="1255" height="363" alt="image" src="https://github.com/user-attachments/assets/a25acdf3-4f02-4fd3-b231-38fb0f43d5b6" />
