### PR TITLE
feat: add output formats, event collection, URL blocking, and more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +89,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +119,30 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -95,10 +160,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -107,10 +189,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -143,6 +246,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "toon-format",
 ]
 
 [[package]]
@@ -199,10 +303,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm 0.29.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -220,6 +358,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix 1.1.4",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,10 +422,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -267,6 +502,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,16 +543,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -354,6 +662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,11 +696,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -445,6 +776,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,10 +808,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -479,6 +861,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -502,10 +890,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -523,10 +929,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -535,9 +960,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -546,6 +988,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -559,6 +1074,28 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "option-ext"
@@ -590,10 +1127,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -621,6 +1208,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -669,6 +1277,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,7 +1314,55 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -697,7 +1374,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -706,6 +1383,21 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -755,6 +1447,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -780,6 +1473,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +1502,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -812,10 +1532,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -829,6 +1577,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,7 +1606,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -847,7 +1616,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -859,6 +1637,77 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a19830747d9034cd9da43a60eaa8e552dfda7712424aebf187b7a60126bae0d"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -902,6 +1751,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "toon-format"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
+dependencies = [
+ "anyhow",
+ "arboard",
+ "chrono",
+ "clap",
+ "comfy-table",
+ "crossterm 0.28.1",
+ "indexmap",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "syntect",
+ "thiserror 2.0.18",
+ "tiktoken-rs",
+ "tui-textarea",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "tui-textarea"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
+dependencies = [
+ "crossterm 0.28.1",
+ "ratatui",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,7 +1798,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -930,6 +1813,35 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -954,6 +1866,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1059,6 +1981,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,7 +2082,25 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -1141,13 +2118,46 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1157,10 +2167,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1169,10 +2203,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1181,16 +2251,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1287,6 +2393,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,3 +2443,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "clap",
  "dirs",
  "futures-util",
+ "libc",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = "0.4.44"
 clap = { version = "4", features = ["derive", "env"] }
 dirs = "5"
 futures-util = "0.3"
+libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
+toon-format = "0.5"
 tokio-tungstenite = "0.24"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -157,16 +157,16 @@ These commands interact with tools injected into the page via `window.__dtmcp.to
 
 | Command | Description |
 |---------|-------------|
-| `emulate` | Get/set page-based emulation overrides (viewport, geolocation, URL blocking) |
-| `emulate --viewport 1280x720` | Set viewport size (page-based, persists) |
-| `emulate --geolocation 37.77,-122.41` | Set geolocation (page-based, persists) |
-| `emulate --block-url <pattern>` | Block URL pattern on subsequent requests (glob; persists in daemon) |
+| `emulate` | Get/set emulation overrides (viewport, geolocation, URL blocking) |
+| `emulate --viewport 1280x720` | Set viewport size (per-tab, persists across navigation) |
+| `emulate --geolocation 37.77,-122.41` | Set geolocation (per-tab, persists across navigation) |
+| `emulate --block-url <pattern>` | Block URL pattern on subsequent requests (glob; per-tab) |
 | `emulate --unblock-url <pattern>` | Un-block a previously blocked pattern |
 | `emulate --clear-blocks` | Clear all blocked URL patterns |
 | `emulate --clear-all` | Clear all overrides (viewport, geolocation, blocks) |
 | `wait-for <text> [--timeout ms]` | Wait for text to appear (default 30s) |
 
-`emulate` with no flags shows all active overrides. Viewport and geolocation overrides are **page-based** — they persist until cleared or the page is closed. URL blocks are **daemon-wide** — they persist until you un-block them, clear them, or kill the daemon.
+`emulate` with no flags shows the active tab's overrides. Viewport, geolocation, and URL blocks are all **per-tab** — each page keeps its own. They persist across navigation within that tab and do **not** leak to other tabs, so you can hold (say) a mobile viewport with images blocked on one tab and a desktop baseline on another at the same time. They persist until you clear them (`--clear-viewport`, `--clear-geolocation`, `--clear-blocks`, or `--clear-all`), the tab closes, or the daemon exits.
 
 ### Network and console inspection
 
@@ -201,13 +201,13 @@ A drain without a `--duration` returns instantly. Adding `--duration N` switches
 | `--page <index>` | Target page by index |
 | `--json` | JSON output |
 | `--toon` | TOON output (compact tabular encoding for LLM agents; mutually exclusive with `--json`) |
-| `--block-url <pattern>` | Add a URL pattern to the daemon's block list (repeatable; persists until un-blocked or cleared) |
-| `--unblock-url <pattern>` | Remove a URL pattern from the daemon's block list (repeatable) |
+| `--block-url <pattern>` | Add a URL pattern to the active tab's block list (repeatable; persists until un-blocked or cleared) |
+| `--unblock-url <pattern>` | Remove a URL pattern from the active tab's block list (repeatable) |
 | `--ws-endpoint <url>` | Explicit WebSocket URL |
 | `--user-data-dir <path>` | Custom Chrome profile directory |
 | `--channel <ch>` | Chrome channel (stable/beta/canary/dev) |
 
-Global `--block-url` and `--unblock-url` are applied to the daemon's persistent block list and re-applied on every page-level command via `Network.setBlockedURLs`. **Note:** Chrome only blocks *subresources* (images, scripts, fetch/XHR, stylesheets, CDN, trackers, fonts). The top-level navigation document itself is never blocked — e.g. `--block-url "*example.com*"` then `navigate https://example.com` still loads the page, but any `*.png`, `*.woff2`, etc. subresources on it are blocked.
+Global `--block-url` and `--unblock-url` update the **active tab's** block list and apply via `Network.setBlockedURLs`; the daemon re-applies each tab's list when that tab is in use, so blocking is isolated per tab. **Note:** Chrome only blocks *subresources* (images, scripts, fetch/XHR, stylesheets, CDN, trackers, fonts). The top-level navigation document itself is never blocked — e.g. `--block-url "*example.com*"` then `navigate https://example.com` still loads the page, but any `*.png`, `*.woff2`, etc. subresources on it are blocked.
 
 ## Daemon details
 

--- a/README.md
+++ b/README.md
@@ -224,10 +224,12 @@ The daemon keeps a persistent CDP session on the current page to:
 - Re-attach to a new target when `--target` changes (the previous target's event buffers are discarded on the switch).
 
 ## Source layout
+ 
+-```
++```text
+ src/
+ ├── main.rs           # Entry point + daemon dispatch
 
-```
-src/
-├── main.rs           # Entry point + daemon dispatch
 ├── lib.rs            # CLI (clap) + command routing
 ├── cdp.rs            # Raw CDP over WebSocket (JSON-RPC) + persistent session
 ├── browser.rs        # Auto-connect (DevToolsActivePort)

--- a/README.md
+++ b/README.md
@@ -157,13 +157,41 @@ These commands interact with tools injected into the page via `window.__dtmcp.to
 
 | Command | Description |
 |---------|-------------|
-| `emulate` | Get/set page-based emulation overrides (viewport, geolocation) |
+| `emulate` | Get/set page-based emulation overrides (viewport, geolocation, URL blocking) |
 | `emulate --viewport 1280x720` | Set viewport size (page-based, persists) |
 | `emulate --geolocation 37.77,-122.41` | Set geolocation (page-based, persists) |
-| `emulate --clear-all` | Clear all emulation overrides |
+| `emulate --block-url <pattern>` | Block URL pattern on subsequent requests (glob; persists in daemon) |
+| `emulate --unblock-url <pattern>` | Un-block a previously blocked pattern |
+| `emulate --clear-blocks` | Clear all blocked URL patterns |
+| `emulate --clear-all` | Clear all overrides (viewport, geolocation, blocks) |
 | `wait-for <text> [--timeout ms]` | Wait for text to appear (default 30s) |
 
-`emulate` with no flags shows all active overrides. Viewport and geolocation overrides are **page-based** — they persist until cleared or the page is closed.
+`emulate` with no flags shows all active overrides. Viewport and geolocation overrides are **page-based** — they persist until cleared or the page is closed. URL blocks are **daemon-wide** — they persist until you un-block them, clear them, or kill the daemon.
+
+### Network and console inspection
+
+The daemon keeps a persistent CDP session on the active page that continuously collects Network and Runtime events. `console` and `network` **drain** whatever has accumulated since the last call (or since the session attached, if never drained).
+
+| Command | Description |
+|---------|-------------|
+| `console` | Drain accumulated console messages |
+| `console --type error --type warning` | Filter by level (`log`, `warn`, `info`, `error`, `debug`, `exception`) |
+| `console --duration 5000` | Live collection for 5 s (consumes events — they won't reappear on a later drain) |
+| `network` | Drain accumulated network requests |
+| `network --type Fetch --type XHR` | Filter by resource type (`Document`, `Script`, `Stylesheet`, `Image`, `Font`, `XHR`, `Fetch`, `Manifest`, `Media`, `Other`) |
+| `network --duration 5000` | Live collection for 5 s |
+| `sw-logs [--duration 2000]` | Collect console logs from extension service workers (2 s default) |
+| `sw-logs --extension-id <id>` | Filter service-worker logs to one extension |
+
+A drain without a `--duration` returns instantly. Adding `--duration N` switches the command to *live mode* and blocks for `N` ms.
+
+### Daemon
+
+| Command | Description |
+|---------|-------------|
+| `kill-daemon` | Stop the background daemon cleanly |
+
+`kill-daemon` signals the running daemon with `SIGTERM`, removes the socket and PID file, and exits. It's a no-op if no daemon is running. Prefer this over `pkill -f __daemon__` — the process name is shared by legitimate Chrome children processes.
 
 ## Global options
 
@@ -172,9 +200,14 @@ These commands interact with tools injected into the page via `window.__dtmcp.to
 | `--target <name>` | Target page by friendly name or raw ID |
 | `--page <index>` | Target page by index |
 | `--json` | JSON output |
+| `--toon` | TOON output (compact tabular encoding for LLM agents; mutually exclusive with `--json`) |
+| `--block-url <pattern>` | Add a URL pattern to the daemon's block list (repeatable; persists until un-blocked or cleared) |
+| `--unblock-url <pattern>` | Remove a URL pattern from the daemon's block list (repeatable) |
 | `--ws-endpoint <url>` | Explicit WebSocket URL |
 | `--user-data-dir <path>` | Custom Chrome profile directory |
 | `--channel <ch>` | Chrome channel (stable/beta/canary/dev) |
+
+Global `--block-url` and `--unblock-url` are applied to the daemon's persistent block list and re-applied on every page-level command via `Network.setBlockedURLs`. **Note:** Chrome only blocks *subresources* (images, scripts, fetch/XHR, stylesheets, CDN, trackers, fonts). The top-level navigation document itself is never blocked — e.g. `--block-url "*example.com*"` then `navigate https://example.com` still loads the page, but any `*.png`, `*.woff2`, etc. subresources on it are blocked.
 
 ## Daemon details
 
@@ -183,7 +216,12 @@ These commands interact with tools injected into the page via `window.__dtmcp.to
 - **Idle timeout**: 5 minutes (auto-exits, cleans up socket)
 - **Protocol**: Length-prefixed JSON over Unix socket
 - **Spawned by**: First CLI invocation (transparent to user)
-- **Kill manually**: `pkill -f __daemon__` or delete the socket
+- **Kill**: `chrome-devtools kill-daemon` (or delete the socket + PID file)
+
+The daemon keeps a persistent CDP session on the current page to:
+- Continuously collect `Network.*` and `Runtime.consoleAPICalled`/`exceptionThrown` events for `console` and `network` drains.
+- Re-apply `Network.setBlockedURLs` and emulation state across page-level commands.
+- Re-attach to a new target when `--target` changes (the previous target's event buffers are discarded on the switch).
 
 ## Source layout
 
@@ -191,12 +229,13 @@ These commands interact with tools injected into the page via `window.__dtmcp.to
 src/
 ├── main.rs           # Entry point + daemon dispatch
 ├── lib.rs            # CLI (clap) + command routing
-├── cdp.rs            # Raw CDP over WebSocket (JSON-RPC)
+├── cdp.rs            # Raw CDP over WebSocket (JSON-RPC) + persistent session
 ├── browser.rs        # Auto-connect (DevToolsActivePort)
 ├── daemon.rs         # Background daemon (persistent connection)
 ├── client.rs         # Talks to daemon via Unix socket
-├── protocol.rs       # IPC message types
+├── protocol.rs       # IPC message types (DaemonRequest / DaemonResponse)
 ├── friendly.rs       # Target ID → word-pair names
+├── format.rs         # OutputFormat (text/json/toon) + format_structured helper
 ├── result.rs         # Command result types
 ├── error.rs          # CLI error types and codes
 ├── constants.rs      # Shared constants
@@ -207,10 +246,13 @@ src/
     ├── pages.rs      # list/new/close/select/wait-for
     ├── screenshot.rs
     ├── evaluate.rs
-    ├── executor.rs   # Command dispatch
+    ├── executor.rs   # Command dispatch + persistent-session reuse
     ├── input.rs      # click/fill/type/press/hover
     ├── snapshot.rs
-    ├── emulation.rs  # emulate (viewport/geolocation get/set/clear)
+    ├── emulation.rs  # emulate (viewport/geolocation/blocklist get/set/clear)
+    ├── console.rs    # console drain / live collection
+    ├── network.rs    # network drain / live collection
+    ├── sw_logs.rs    # extension service-worker log collection
     └── third_party.rs # list-3p-tools/execute-3p-tool
 ```
 
@@ -231,6 +273,10 @@ chrome-devtools --target red-snake click "#submit"
 
 # 4. Extract data
 chrome-devtools --target red-snake evaluate "document.title"
+
+# 5. Inspect what the page did under the hood
+chrome-devtools --target red-snake network      # drain accumulated requests
+chrome-devtools --target red-snake console       # drain console + exceptions
 ```
 
 Always pass `--target` from step 2 onward to stay on the same page.

--- a/skill/chrome-devtools/SKILL.md
+++ b/skill/chrome-devtools/SKILL.md
@@ -240,10 +240,10 @@ chrome-devtools --target warm-squid evaluate "JSON.stringify(performance.timing)
 **Avoid `evaluate` for DOM traversal.** Use `snapshot` to read page structure and `click`/`fill` to interact.
 
 ### Pattern 7: Output Formats
-All commands that produce structured output support `--text` (default), `--json`, and `--toon` (compact, LLM-friendly).
+All commands default to human-readable text output. Use `--json` or `--toon` (compact, LLM-friendly) for structured output.
 
 ```bash
-chrome-devtools list-pages                    # human-readable table
+chrome-devtools list-pages                    # human-readable table (default)
 chrome-devtools list-pages --json             # JSON
 chrome-devtools list-pages --toon             # TOON (compact)
 

--- a/skill/chrome-devtools/SKILL.md
+++ b/skill/chrome-devtools/SKILL.md
@@ -4,6 +4,10 @@ description: Use when the user asks to "take a screenshot of a website", "naviga
 user-invocable: true
 ---
 
+# Chrome DevTools CLI
+
+A CLI that talks directly to your running Chrome via the DevTools Protocol.
+
 ## Prerequisites
 
 Chrome must have remote debugging enabled:
@@ -11,104 +15,414 @@ Chrome must have remote debugging enabled:
 2. Go to `chrome://inspect/#remote-debugging`
 3. Enable the remote debugging server
 
-The CLI auto-connects by reading Chrome's `DevToolsActivePort` file — no WebSocket URL needed.
+The CLI auto-connects — no URL needed. A daemon is spawned on first invocation and reused across commands (5-minute idle timeout).
+
+## ⚠️ Critical: How Page Targeting Works
+
+**Targets are NOT arbitrary strings.** You cannot use `--target main`, `--target page1`, or any made-up name.
+
+Targets are **friendly word-pair names** (like `warm-squid`, `pink-hen`) that the CLI derives from Chrome's internal target IDs. You **get them from command output** — never invent them.
+
+Names are **stable for the lifetime of a tab** — navigating within the same tab keeps the same target name; closing and reopening the tab gives a new name.
+
+### The Correct Workflow
+
+**Step 1: Run `list-pages` to see what's open and get target names**
+```bash
+chrome-devtools list-pages
+```
+
+Output:
+```
+[0] (warm-squid) Your Repositories — https://github.com/aeroxy
+[1] (pink-hen) Gmail — https://mail.google.com
+[2] (hazy-vole) Example — https://example.com
+```
+
+**Step 2: Use the friendly name from the output in subsequent commands**
+```bash
+chrome-devtools --target warm-squid navigate https://example.com
+chrome-devtools --target pink-hen screenshot --output screenshot.png
+```
+
+**Alternative: Use `--page <index>` for numeric indexing (0-based)**
+```bash
+chrome-devtools --page 0 navigate https://example.com
+```
+
+**If both `--target` and `--page` are omitted, the command runs on page 0 (leftmost tab).** This is fine for single-tab workflows but should generally be avoided — always pin to a known page.
 
 ## Core Capabilities
 
-- **Navigation**: `navigate`, `back`, `forward`, `reload`.
-- **Emulation**: `emulate` (viewport, mobile, device-scale-factor, geolocation).
-- **Extraction**: `screenshot`, `snapshot` (accessibility tree), `list-pages`.
-- **Interaction**: `click`, `click-at`, `fill`, `type-text`, `press-key`, `hover`.
-- **Execution**: `evaluate` (JS), `execute-3p-tool`.
-- **Synchronization**: `wait-for` (text on page).
+- **Navigation**: `navigate`, `navigate --back`, `navigate --forward`, `navigate --reload`
+- **Page management**: `list-pages`, `new-page`, `close-page`, `select-page`
+- **Extraction**: `screenshot`, `snapshot` (accessibility tree), `evaluate` (JavaScript)
+- **Interaction**: `click`, `fill`, `type-text`, `press-key`, `hover`, `click-at`
+- **Emulation**: `emulate` (viewport, mobile, geolocation, URL blocking)
+- **Inspection**: `console` (logs), `network` (requests), `sw-logs` (extension service workers)
+- **Third-party tools**: `list-3p-tools`, `execute-3p-tool` (tools exposed by `window.__dtmcp`)
+- **Synchronization**: `wait-for` (wait for text on page)
+- **Daemon control**: `kill-daemon`
 
-## Usage Guide
+## Standard Patterns
 
-### Page Selection
-Most commands require a page target. Use `--page <index>` (0-based) or `--target <id>`.
+### Pattern 1: Navigate and Interact
+
+`navigate` and `new-page` print the target name at the end — capture it to pin subsequent commands.
 
 ```bash
+# 1. List pages to find target
 chrome-devtools list-pages
-chrome-devtools --target main navigate https://example.com
+
+# 2. Navigate (target name shown at end of output)
+chrome-devtools --target warm-squid navigate https://example.com
+# stdout: Navigated to https://example.com
+# stderr: [navigated to: https://example.com]
+# stderr: [target:warm-squid]
+
+# 3. Pin all subsequent commands to this page
+chrome-devtools --target warm-squid screenshot --output page.png
+chrome-devtools --target warm-squid evaluate "document.title"
+
+# 4. Open a new tab — capture the NEW target name from output
+chrome-devtools new-page https://github.com
+# stdout: Opened: https://github.com
+# stderr: [target:icy-goat]  ← new tab, new target
+chrome-devtools --target icy-goat snapshot
 ```
 
-### Emulation (Viewport & Geolocation)
-Overrides are persistent per page. You can set them standalone or during navigation.
+**Note**: The `[navigated to: ...]` and `[target:...]` lines go to **stderr**, not stdout. The stdout contains only the main command output ("Navigated to …", "Opened: …").
+
+### Pattern 2: Emulation (Viewport & Geolocation)
+Overrides persist per page. `emulate` with no flags shows current state.
 
 ```bash
-# Set viewport and geolocation standalone
-chrome-devtools --target main emulate --viewport 1920x1080 --geolocation 40.71,-74.00
+# Set viewport and geolocation
+chrome-devtools --target warm-squid emulate --viewport 1920x1080 --geolocation 40.71,-74.00
 
 # Emulate mobile device
-chrome-devtools --target main emulate --viewport 375x812 --mobile --device-scale-factor 3
+chrome-devtools --target warm-squid emulate --viewport 375x812 --mobile --device-scale-factor 3
 
-# Navigate with atomic emulation (sets environment before loading URL)
-chrome-devtools navigate https://geotargetly.com --geolocation 51.50,-0.12
+# Navigate with emulation (emulation applied before URL loads)
+chrome-devtools --target warm-squid navigate https://example.com --viewport 375x812 --mobile
 
-# Navigate as mobile device
-chrome-devtools navigate https://example.com --viewport 375x812 --mobile
-
-# Open new tab with atomic emulation
+# Open new tab with emulation
 chrome-devtools new-page https://example.com --viewport 375x812
 
+# Show current overrides
+chrome-devtools --target warm-squid emulate
+# Output: No emulation overrides active.  (or lists current blocks/viewport/etc.)
+
 # Clear emulation overrides
-chrome-devtools --target main emulate --clear-all
-chrome-devtools --target main emulate --clear-viewport
-chrome-devtools --target main emulate --clear-geolocation
+chrome-devtools --target warm-squid emulate --clear-all        # clears everything
+chrome-devtools --target warm-squid emulate --clear-viewport   # clears viewport only
+chrome-devtools --target warm-squid emulate --clear-geolocation
 ```
 
-### Interaction Patterns
+### Pattern 3: URL Blocking (Network Debugging)
+Block URL patterns using simple `*` wildcards: `*.png` (all PNG files), `cdn.example.com/*` (a domain path), `*analytics*` (any URL containing "analytics"). Patterns persist in the daemon until cleared.
+
 ```bash
-# Search and submit
-chrome-devtools fill "input.search" "Rust programming"
-chrome-devtools press-key Enter
-chrome-devtools wait-for "The Rust Programming Language"
+# Add block patterns
+chrome-devtools --target warm-squid emulate --block-url "*.png"
+chrome-devtools --target warm-squid emulate --block-url "*.ico" --block-url "*.svg"
 
-# Take a full-page screenshot
-chrome-devtools screenshot --full-page --output search_results.png
+# Block while navigating (inline)
+chrome-devtools --target warm-squid --block-url "*.png" navigate https://example.com
+
+# Show current blocks
+chrome-devtools --target warm-squid emulate
+# Output: Blocked URLs:
+#           *.png
+#           *.ico
+#           *.svg
+
+# Remove a specific pattern from the blocklist
+chrome-devtools --target warm-squid emulate --allow-url "*.png"
+# (Note: --allow-url REMOVES that pattern from the blocklist. It does not create a separate "allowlist".)
+
+# Clear all blocks
+chrome-devtools --target warm-squid emulate --clear-blocks
+chrome-devtools --target warm-squid emulate --clear-all
 ```
 
-### Advanced Evaluation
+### Pattern 4: Form Interaction
+
+Two ways to fill inputs — choose based on what the site expects:
+
+- `fill` sets the value directly via `element.value = ...`. Fast, no key events. Works for text inputs, textareas, `<select>`, checkboxes, radio buttons. **Often breaks React/Vue apps** because these frameworks rely on real input events.
+- `type-text` dispatches individual keyboard events. Slower but triggers all the `input`, `compositionstart/end`, etc. events that frameworks listen for. **Use this when `fill` seems to "not work"** on interactive frameworks.
+
 ```bash
-# Evaluate and get return value
-chrome-devtools evaluate "document.title"
+# Click an element by CSS selector
+chrome-devtools --target warm-squid click "button.submit"
 
-# Handle potential dialogs automatically
-chrome-devtools evaluate "alert('hi')" --dialog-action accept
+# Click at viewport-relative coordinates (0,0 is top-left of the visible viewport)
+chrome-devtools --target warm-squid click-at 100 200
+
+# Fill a text input (fast, no key events)
+chrome-devtools --target warm-squid fill "input.search" "search query"
+
+# Type text one char at a time (use for React/Vue/form-validation sites)
+chrome-devtools --target warm-squid type-text "search query" --submit-key Enter
+
+# Press a key or key combo. Examples: Enter, Tab, Escape, ArrowDown,
+# Control+A, Meta+C, Shift+Tab, Backspace, Space.
+chrome-devtools --target warm-squid press-key Enter
+chrome-devtools --target warm-squid press-key Control+A
+
+# Hover over an element
+chrome-devtools --target warm-squid hover ".menu-item"
+
+# Wait for text to appear (default timeout: 30 seconds = 30000 ms)
+chrome-devtools --target warm-squid wait-for "Results" --timeout 10000
 ```
 
-## Command Reference
+### Pattern 5: Console & Network Inspection
+
+The daemon maintains a persistent session for the current page that continuously collects network and console events across commands.
+
+`console` and `network` **return accumulated events and clear the buffer** (drain). A second call immediately after returns empty unless new events arrived. Use this for inspecting what happened; use `--duration` for live monitoring.
+
+```bash
+# Navigate (generates network + console events)
+chrome-devtools --target warm-squid navigate https://example.com
+
+# Drain accumulated network requests (instant, non-blocking)
+chrome-devtools --target warm-squid network
+
+# Drain console messages
+chrome-devtools --target warm-squid console
+
+# Filter by console type: log, warning, error, info, debug, exception
+chrome-devtools --target warm-squid console --type error --type warning
+
+# Filter network by resource type (case-sensitive): Document, Script, Stylesheet,
+# Image, Font, XHR, Fetch, Manifest, Media, WebSocket, Other
+chrome-devtools --target warm-squid network --type Fetch --type XHR
+
+# Live monitoring: blocks for N milliseconds, collecting events during that window
+chrome-devtools --target warm-squid console --duration 5000
+chrome-devtools --target warm-squid network --duration 3000
+
+# Drain instantly (default): returns whatever has accumulated so far
+chrome-devtools --target warm-squid console --duration 0
+```
+
+**Valid `--type` values for `network`**: `Document`, `Script`, `Stylesheet`, `Image`, `Media`, `Font`, `WebSocket`, `Manifest`, `XHR`, `Fetch`, `Other`.
+
+### Pattern 6: JavaScript Evaluation
+
+`evaluate` runs a JavaScript expression and returns the result. It automatically `await`s promises and serializes the return value (objects become JSON, primitives come back as plain text).
+
+```bash
+# Get the page title
+chrome-devtools --target warm-squid evaluate "document.title"
+
+# Await a promise automatically
+chrome-devtools --target warm-squid evaluate "fetch('/api/user').then(r => r.json())"
+
+# Get a value as JSON (forces JSON serialization)
+chrome-devtools --target warm-squid --json evaluate "performance.navigation"
+
+# Handle a JS dialog (alert, confirm, prompt). Without --dialog-action, eval hangs.
+chrome-devtools --target warm-squid evaluate "alert('hi')" --dialog-action accept
+chrome-devtools --target warm-squid evaluate "confirm('sure?')" --dialog-action dismiss
+chrome-devtools --target warm-squid evaluate "prompt('name')" --dialog-action "my-answer"
+# Valid --dialog-action values: "accept", "dismiss", or any prompt-text string.
+
+# Save JS output to a file
+chrome-devtools --target warm-squid evaluate "JSON.stringify(performance.timing)" -o /tmp/perf.json
+```
+
+**Avoid `evaluate` for DOM traversal.** Use `snapshot` to read page structure and `click`/`fill` to interact.
+
+### Pattern 7: Output Formats
+All commands that produce structured output support `--text` (default), `--json`, and `--toon` (compact, LLM-friendly).
+
+```bash
+chrome-devtools list-pages                    # human-readable table
+chrome-devtools list-pages --json             # JSON
+chrome-devtools list-pages --toon             # TOON (compact)
+
+chrome-devtools --target warm-squid snapshot --toon
+chrome-devtools --target warm-squid network --toon --type Fetch
+```
+
+`--json` and `--toon` are mutually exclusive.
+
+### Pattern 8: Snapshot (Accessibility Tree)
+Use snapshot instead of `evaluate document.querySelector(...)` for understanding page structure.
+
+```bash
+chrome-devtools --target warm-squid snapshot
+chrome-devtools --target warm-squid snapshot --output /tmp/ax-tree.txt
+chrome-devtools --target warm-squid snapshot --toon  # compact output
+```
+
+### Pattern 9: Screenshots
+```bash
+# Default: viewport-only PNG
+chrome-devtools --target warm-squid screenshot --output page.png
+
+# Full scrollable page (can be very tall)
+chrome-devtools --target warm-squid screenshot --full-page --output full-page.png
+
+# Save to a specific path
+chrome-devtools --target warm-squid screenshot --output /tmp/whatever.jpg
+```
+
+### Pattern 10: Extension Service Worker Logs
+Browser-level command — no `--target` needed.
+
+```bash
+# Collect logs from ALL extension service workers (2s window)
+chrome-devtools sw-logs --duration 2000
+
+# Filter by extension ID (from sw-logs output)
+chrome-devtools sw-logs --duration 2000 --extension-id abcdef123456
+```
+
+### Pattern 11: Third-party Developer Tools
+For pages that expose tools via `window.__dtmcp`.
+
+```bash
+chrome-devtools --target warm-squid list-3p-tools
+chrome-devtools --target warm-squid execute-3p-tool "<tool-name>" '<json-params>'
+```
+
+## Complete Command Reference
 
 ### Navigation
 ```bash
-chrome-devtools navigate <url> [--viewport WxH] [--mobile] [--device-scale-factor N] [--geolocation lat,lon] [--accuracy M]
+chrome-devtools list-pages
+chrome-devtools navigate <url> [--viewport WxH] [--mobile] [--device-scale-factor N] [--geolocation lat,lon]
 chrome-devtools navigate <url> --extra-headers '{"Authorization":"Bearer ..."}'
-chrome-devtools navigate <url> -o /tmp/result.txt
 chrome-devtools navigate --back
 chrome-devtools navigate --forward
 chrome-devtools navigate --reload
-chrome-devtools new-page <url> [--viewport WxH] [--mobile] [--device-scale-factor N] [--geolocation lat,lon]
-chrome-devtools new-page <url> --extra-headers '{"X-Debug":"1"}'
-chrome-devtools close-page [id_or_index]
-chrome-devtools select-page [id_or_index]
+chrome-devtools new-page <url> [--viewport WxH] [--mobile]
+chrome-devtools close-page [index_or_target_name]
+chrome-devtools select-page [index_or_target_name]
+```
+
+### Inspection
+```bash
+chrome-devtools --target <name> screenshot [--output <path>] [--full-page]
+chrome-devtools --target <name> snapshot
+chrome-devtools --target <name> evaluate "<js-expression>" [--dialog-action accept|dismiss|text]
+chrome-devtools --target <name> network [--duration <ms>] [--type <resource>]
+chrome-devtools --target <name> console [--duration <ms>] [--type <level>]
+chrome-devtools sw-logs [--duration <ms>] [--extension-id <id>]
+```
+
+### Interaction
+```bash
+chrome-devtools --target <name> click "<css-selector>"
+chrome-devtools --target <name> click-at <x> <y>
+chrome-devtools --target <name> fill "<css-selector>" "<value>"
+chrome-devtools --target <name> type-text "<text>" [--submit-key <key>]
+chrome-devtools --target <name> press-key <key>
+chrome-devtools --target <name> hover "<css-selector>"
+chrome-devtools --target <name> wait-for "<text>" [--timeout <ms>]   # default 30000
 ```
 
 ### Emulation
 ```bash
-chrome-devtools emulate [--viewport WxH] [--mobile] [--device-scale-factor N] [--geolocation lat,lon] [--accuracy M]
-chrome-devtools emulate --clear-all
-chrome-devtools emulate --clear-viewport
-chrome-devtools emulate --clear-geolocation
+chrome-devtools --target <name> emulate [--viewport WxH] [--mobile] [--geolocation lat,lon]
+chrome-devtools --target <name> emulate                                  # show current state
+chrome-devtools --target <name> emulate --block-url "<pattern>" [--block-url ...]
+chrome-devtools --target <name> emulate --allow-url "<pattern>"          # remove from blocklist
+chrome-devtools --target <name> emulate --clear-blocks
+chrome-devtools --target <name> emulate --clear-viewport
+chrome-devtools --target <name> emulate --clear-geolocation
+chrome-devtools --target <name> emulate --clear-all                      # clears everything
 ```
 
-### Utilities
+### Third-party Tools
 ```bash
-chrome-devtools --target <name> wait-for "Success" --timeout 10000
-chrome-devtools list-pages
+chrome-devtools --target <name> list-3p-tools
+chrome-devtools --target <name> execute-3p-tool <name> '<json-params>'
 ```
 
-### Third-party Developer Tools
+### Daemon
 ```bash
-chrome-devtools list-3p-tools
-chrome-devtools execute-3p-tool <name> '<json-params>'
+chrome-devtools kill-daemon        # stop the background daemon process
 ```
+
+## Critical Gotchas
+
+### ✗ WRONG: Using invented target names
+```bash
+chrome-devtools --target main navigate https://example.com        # ❌ WRONG
+chrome-devtools --target page1 screenshot                         # ❌ WRONG
+chrome-devtools --target "my-page" evaluate "..."                 # ❌ WRONG
+```
+
+### ✓ CORRECT: Get target from command output
+```bash
+chrome-devtools list-pages                                        # ✓ First: list pages
+# [0] (warm-squid) Example — https://example.com
+chrome-devtools --target warm-squid navigate https://github.com   # ✓ Use the name from output
+```
+
+### ✗ WRONG: Running commands without first finding a target
+```bash
+chrome-devtools screenshot --output page.png                      # ❌ WRONG: unpredictable page
+```
+
+### ✓ CORRECT: Always identify the page first
+```bash
+chrome-devtools list-pages                                        # ✓ First
+chrome-devtools --target warm-squid screenshot --output page.png  # ✓ Pinned to known page
+```
+
+### ✗ WRONG: Using evaluate for DOM traversal or interaction
+```bash
+chrome-devtools --target warm-squid evaluate "document.querySelector('...').click()"   # ❌ WRONG
+```
+
+### ✓ CORRECT: Use snapshot for structure, click/fill for interaction
+```bash
+chrome-devtools --target warm-squid snapshot                      # ✓ Read structure
+chrome-devtools --target warm-squid click "button.submit"         # ✓ Interact
+```
+
+### ✗ WRONG: Expecting `fill` to update React/Vue forms
+```bash
+chrome-devtools --target warm-squid fill "input" "value"          # ❌ value set, but framework state unchanged
+```
+
+### ✓ CORRECT: Use `type-text` for stateful frameworks
+```bash
+chrome-devtools --target warm-squid type-text "value"             # ✓ real key events → framework state updates
+```
+
+### ✗ WRONG: Expecting `console`/`network` to remember events after drain
+```bash
+chrome-devtools --target warm-squid console
+# [error] foo
+# [warning] bar
+chrome-devtools --target warm-squid console
+# No console messages collected.  ← the buffer was drained on the first call
+```
+
+### ✓ CORRECT: Each drain is a fresh window
+Run `console` / `network` right after the action that produces events, OR use `--duration` to collect for a window of time.
+
+## Output Format Summary
+
+| Flag | Description |
+|------|-------------|
+| *(none)* | Human-readable text (default) |
+| `--json` | Pretty-printed JSON |
+| `--toon` | TOON — compact tabular format (fewer tokens for LLM agents) |
+
+`--json` and `--toon` are mutually exclusive.
+
+## Stdout vs Stderr
+
+- **stdout** contains the primary command output (table, text, JSON, TOON).
+- **stderr** contains informational lines (`[target:...]`, `[navigated to: ...]`) and errors.
+
+When parsing command output programmatically, read only stdout to get the main result.

--- a/skill/chrome-devtools/SKILL.md
+++ b/skill/chrome-devtools/SKILL.md
@@ -122,6 +122,8 @@ chrome-devtools --target warm-squid emulate --clear-geolocation
 ### Pattern 3: URL Blocking (Network Debugging)
 Block URL patterns using simple `*` wildcards: `*.png` (all PNG files), `cdn.example.com/*` (a domain path), `*analytics*` (any URL containing "analytics"). Patterns persist in the daemon until cleared.
 
+> **Scope:** blocking applies to **subresources** the page loads (images, scripts, fetch/XHR, stylesheets, CDN, trackers). It does **not** block the top-level navigation document itself — e.g. `--block-url "*example.com*"` then `navigate https://example.com` still loads the page, but any `example.com` subresources are blocked. This is a Chrome `Network.setBlockedURLs` limitation, not a CLI bug.
+
 ```bash
 # Add block patterns
 chrome-devtools --target warm-squid emulate --block-url "*.png"

--- a/skill/chrome-devtools/SKILL.md
+++ b/skill/chrome-devtools/SKILL.md
@@ -33,7 +33,7 @@ chrome-devtools list-pages
 ```
 
 Output:
-```
+```text
 [0] (warm-squid) Your Repositories — https://github.com/aeroxy
 [1] (pink-hen) Gmail — https://mail.google.com
 [2] (hazy-vole) Example — https://example.com

--- a/skill/chrome-devtools/SKILL.md
+++ b/skill/chrome-devtools/SKILL.md
@@ -138,8 +138,8 @@ chrome-devtools --target warm-squid emulate
 #           *.svg
 
 # Remove a specific pattern from the blocklist
-chrome-devtools --target warm-squid emulate --allow-url "*.png"
-# (Note: --allow-url REMOVES that pattern from the blocklist. It does not create a separate "allowlist".)
+chrome-devtools --target warm-squid emulate --unblock-url "*.png"
+# (Note: --unblock-url REMOVES that pattern from the blocklist. There is no separate "allowlist".)
 
 # Clear all blocks
 chrome-devtools --target warm-squid emulate --clear-blocks
@@ -332,7 +332,7 @@ chrome-devtools --target <name> wait-for "<text>" [--timeout <ms>]   # default 3
 chrome-devtools --target <name> emulate [--viewport WxH] [--mobile] [--geolocation lat,lon]
 chrome-devtools --target <name> emulate                                  # show current state
 chrome-devtools --target <name> emulate --block-url "<pattern>" [--block-url ...]
-chrome-devtools --target <name> emulate --allow-url "<pattern>"          # remove from blocklist
+chrome-devtools --target <name> emulate --unblock-url "<pattern>"          # remove from blocklist
 chrome-devtools --target <name> emulate --clear-blocks
 chrome-devtools --target <name> emulate --clear-viewport
 chrome-devtools --target <name> emulate --clear-geolocation

--- a/skill/chrome-devtools/SKILL.md
+++ b/skill/chrome-devtools/SKILL.md
@@ -94,7 +94,7 @@ chrome-devtools --target icy-goat snapshot
 **Note**: The `[navigated to: ...]` and `[target:...]` lines go to **stderr**, not stdout. The stdout contains only the main command output ("Navigated to …", "Opened: …").
 
 ### Pattern 2: Emulation (Viewport & Geolocation)
-Overrides persist per page. `emulate` with no flags shows current state.
+Overrides are per-tab: each page keeps its own viewport/geolocation/URL-blocks, persisting across navigation within that tab and isolated from other tabs (until cleared, the tab closes, or the daemon exits). `emulate` with no flags shows the active tab's state.
 
 ```bash
 # Set viewport and geolocation

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -164,13 +164,21 @@ impl CdpClient {
             .ok_or_else(|| anyhow!("No sessionId in persistent attachToTarget"))?
             .to_string();
 
+        // Store the session id BEFORE enabling domains so events arriving
+        // during Network.enable / Runtime.enable are routed to persistent
+        // buffers instead of the generic events buffer.
+        self.persistent_session = Some(session_id.clone());
+        self.persistent_target_id = Some(target_id.to_string());
+
         // Enable Network and Runtime domains on the persistent session. If
-        // either fails, detach the just-attached session (so it isn't leaked in
-        // Chrome) and bail before marking the session persistent — per-command
-        // collectors then fall back to their own enable instead of silently
-        // draining an uninitialized (always-empty) buffer.
+        // either fails, clear the just-set session, detach it (so it isn't
+        // leaked in Chrome), and bail — per-command collectors then fall
+        // back to their own enable instead of silently draining an
+        // uninitialized (always-empty) buffer.
         for method in ["Network.enable", "Runtime.enable"] {
             if let Err(e) = self.send_to_target(&session_id, method, json!({})).await {
+                self.persistent_session = None;
+                self.persistent_target_id = None;
                 let _ = self
                     .send("Target.detachFromTarget", json!({"sessionId": session_id}))
                     .await;
@@ -178,11 +186,9 @@ impl CdpClient {
             }
         }
 
-        // Apply any existing blocklist to the new session before storing it.
+        // Apply any existing blocklist to the new session.
         self.apply_network_rules_internal(&session_id).await;
 
-        self.persistent_session = Some(session_id);
-        self.persistent_target_id = Some(target_id.to_string());
         Ok(())
     }
 

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -795,6 +795,25 @@ impl CdpClient {
     }
 }
 
+/// Helper to join console API arguments into a single string.
+/// Chrome's `Runtime.consoleAPICalled` returns arguments as an array of RemoteObjects.
+pub fn join_console_args(args: &[Value]) -> String {
+    args.iter()
+        .map(|arg| match arg.get("value") {
+            // String primitives: emit the raw text (no quotes).
+            Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
+            // Other primitives (number, bool, null): stringify directly.
+            Some(v) => v.to_string(),
+            // Objects have no `value` — fall back to their description.
+            None => arg["description"]
+                .as_str()
+                .unwrap_or("<object>")
+                .to_string(),
+        })
+        .collect::<Vec<String>>()
+        .join(" ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -165,13 +165,18 @@ impl CdpClient {
             .to_string();
 
         // Enable Network and Runtime domains on the persistent session. If
-        // either fails, bail before marking the session persistent so that
-        // per-command collectors fall back to their own enable instead of
-        // silently draining an uninitialized (always-empty) buffer.
-        self.send_to_target(&session_id, "Network.enable", json!({}))
-            .await?;
-        self.send_to_target(&session_id, "Runtime.enable", json!({}))
-            .await?;
+        // either fails, detach the just-attached session (so it isn't leaked in
+        // Chrome) and bail before marking the session persistent — per-command
+        // collectors then fall back to their own enable instead of silently
+        // draining an uninitialized (always-empty) buffer.
+        for method in ["Network.enable", "Runtime.enable"] {
+            if let Err(e) = self.send_to_target(&session_id, method, json!({})).await {
+                let _ = self
+                    .send("Target.detachFromTarget", json!({"sessionId": session_id}))
+                    .await;
+                return Err(e);
+            }
+        }
 
         // Apply any existing blocklist to the new session before storing it.
         self.apply_network_rules_internal(&session_id).await;

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -735,12 +735,19 @@ impl CdpClient {
             match tokio::time::timeout(remaining, self.read_text()).await {
                 Ok(Ok(text)) => {
                     if let Ok(resp) = serde_json::from_str::<Value>(&text) {
-                        if resp.get("method").is_some() {
+                        if let Some(method) = resp.get("method").and_then(|v| v.as_str()) {
                             // Events are routed to persistent session buffers (network_events,
                             // console_events) AND returned in the `events` vector here.
-                            // Callers using the persistent-session path should drain the
-                            // buffers and ignore this return value to avoid double-processing.
-                            self.push_event(resp.clone());
+                            //
+                            // In direct mode (no persistent session), we avoid pushing
+                            // Network/Runtime events to the generic `self.events` buffer.
+                            // This prevents them from being stashed and then returned
+                            // again in a subsequent drain (double-processing).
+                            if self.persistent_session.is_some() {
+                                self.push_event(resp.clone());
+                            } else if !method.starts_with("Network.") && !method.starts_with("Runtime.") {
+                                self.push_event(resp.clone());
+                            }
                             events.push(resp);
                         }
                     }

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -187,30 +187,33 @@ impl CdpClient {
         }
 
         // Apply any existing blocklist to the new session.
-        self.apply_network_rules_internal(&session_id).await;
+        self.apply_network_rules_internal(&session_id).await?;
 
         Ok(())
     }
 
     /// Apply the daemon's current `blocklist` to the persistent session via
     /// `Network.setBlockedURLs`. Patterns are Chrome-style globs (e.g. `*.png`).
-    pub async fn apply_network_rules(&mut self) {
+    /// Falls back silently if no persistent session is active (e.g. during
+    /// daemon startup or after a target switch that hasn't finished attaching).
+    pub async fn apply_network_rules(&mut self) -> Result<()> {
         if let Some(ref session) = self.persistent_session.clone() {
-            self.apply_network_rules_internal(session).await;
+            self.apply_network_rules_internal(session).await?;
         }
+        Ok(())
     }
 
     /// Apply the current `blocklist` to a specific session via
     /// `Network.setBlockedURLs`. Used for both the persistent session and
     /// fallback per-command sessions (when the persistent one is unavailable).
-    pub(crate) async fn apply_network_rules_internal(&mut self, session_id: &str) {
-        let _ = self
-            .send_to_target(
-                session_id,
-                "Network.setBlockedURLs",
-                json!({"urls": self.blocklist}),
-            )
-            .await;
+    pub(crate) async fn apply_network_rules_internal(&mut self, session_id: &str) -> Result<()> {
+        self.send_to_target(
+            session_id,
+            "Network.setBlockedURLs",
+            json!({"urls": self.blocklist}),
+        )
+        .await?;
+        Ok(())
     }
 
     /// Drain accumulated network events from the persistent session.
@@ -600,7 +603,17 @@ impl CdpClient {
                         }
                     }
                 }
-                Ok(Err(_)) | Err(_) => break,
+                // Timeout expired — normal completion path.
+                Err(_) => break,
+                // read_text() itself failed (socket closed, decode error,
+                // etc.) — real transport error. Log it so the user has a
+                // signal when the partial result is suspicious, then stop.
+                Ok(Err(e)) => {
+                    eprintln!(
+                        "Warning: WebSocket read failed during event collection: {e}"
+                    );
+                    break;
+                }
             }
         }
 

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -89,6 +89,15 @@ pub struct CdpClient {
     /// Persistent URL block patterns for `Network.setBlockedURLs`.
     /// Re-applied by `ensure_persistent_session` whenever a new target is attached.
     pub blocklist: Vec<String>,
+    /// Active viewport override, re-applied on target switch (like `blocklist`).
+    pub viewport: Option<ViewportOverride>,
+    /// Active geolocation override, re-applied on target switch.
+    pub geolocation: Option<GeolocationOverride>,
+    /// Per-tab emulation state for tabs that are NOT currently active. The active
+    /// tab's state lives in the `blocklist`/`viewport`/`geolocation` fields above;
+    /// `ensure_persistent_session` swaps state in/out of here on target switch so
+    /// each tab keeps its own overrides (per-tab isolation).
+    pub emulation_saved: std::collections::HashMap<String, TabEmulation>,
 }
 
 const MAX_BUFFERED_EVENTS: usize = 1000;
@@ -102,6 +111,33 @@ pub struct TargetInfo {
     pub url: String,
     #[allow(dead_code)]
     pub target_type: String,
+}
+
+/// Active viewport override. Stored structured (not as a display string) so it
+/// can be re-applied to a new session on target switch, like the blocklist.
+#[derive(Debug, Clone)]
+pub struct ViewportOverride {
+    pub width: u32,
+    pub height: u32,
+    pub device_scale_factor: f64,
+    pub mobile: bool,
+}
+
+/// Active geolocation override. Stored structured for the same reason.
+#[derive(Debug, Clone)]
+pub struct GeolocationOverride {
+    pub latitude: f64,
+    pub longitude: f64,
+    pub accuracy: f64,
+}
+
+/// A tab's emulation state, saved while another tab is active so each tab keeps
+/// its own viewport/geolocation/blocklist (per-tab isolation).
+#[derive(Debug, Clone, Default)]
+pub struct TabEmulation {
+    pub blocklist: Vec<String>,
+    pub viewport: Option<ViewportOverride>,
+    pub geolocation: Option<GeolocationOverride>,
 }
 
 impl CdpClient {
@@ -122,6 +158,9 @@ impl CdpClient {
             network_events: Vec::new(),
             console_events: Vec::new(),
             blocklist: Vec::new(),
+            viewport: None,
+            geolocation: None,
+            emulation_saved: std::collections::HashMap::new(),
         })
     }
 
@@ -143,6 +182,25 @@ impl CdpClient {
         // target so a later drain under the new page can't return stale events.
         self.network_events.clear();
         self.console_events.clear();
+
+        // Save the previously-active tab's emulation state so it can be restored
+        // when we return to it (per-tab isolation). The active state lives in the
+        // top-level fields; stash it under the old target id — but only if the
+        // tab actually has overrides, so the map doesn't accumulate empty entries
+        // for every tab ever visited.
+        if let Some(old_target) = self.persistent_target_id.clone() {
+            let saved = TabEmulation {
+                blocklist: std::mem::take(&mut self.blocklist),
+                viewport: self.viewport.take(),
+                geolocation: self.geolocation.take(),
+            };
+            if !saved.blocklist.is_empty()
+                || saved.viewport.is_some()
+                || saved.geolocation.is_some()
+            {
+                self.emulation_saved.insert(old_target, saved);
+            }
+        }
 
         // Detach old session if target changed
         if let Some(old_session) = self.persistent_session.take() {
@@ -186,9 +244,63 @@ impl CdpClient {
             }
         }
 
-        // Apply any existing blocklist to the new session.
-        self.apply_network_rules_internal(&session_id).await?;
+        // Load the new tab's saved emulation state into the active fields (empty
+        // if this tab has none), then apply it to the new session. A tab with no
+        // saved state starts clean — overrides from other tabs don't leak in.
+        let restored = self.emulation_saved.remove(target_id).unwrap_or_default();
+        self.blocklist = restored.blocklist;
+        self.viewport = restored.viewport;
+        self.geolocation = restored.geolocation;
 
+        self.apply_network_rules_internal(&session_id).await?;
+        self.apply_emulation_internal(&session_id).await?;
+
+        Ok(())
+    }
+
+    /// Drop any stored emulation state for a target (e.g. when its tab closes).
+    /// If it's the active tab, also reset the active fields and the now-invalid
+    /// persistent session so the next command attaches cleanly.
+    pub fn forget_target(&mut self, target_id: &str) {
+        self.emulation_saved.remove(target_id);
+        if self.persistent_target_id.as_deref() == Some(target_id) {
+            self.blocklist.clear();
+            self.viewport = None;
+            self.geolocation = None;
+            self.persistent_session = None;
+            self.persistent_target_id = None;
+        }
+    }
+
+    /// Re-apply the current viewport/geolocation overrides to a session.
+    /// Mirrors `apply_network_rules_internal` so overrides persist across
+    /// target switches. No-op for whichever override isn't set.
+    pub(crate) async fn apply_emulation_internal(&mut self, session_id: &str) -> Result<()> {
+        if let Some(vp) = self.viewport.clone() {
+            self.send_to_target(
+                session_id,
+                "Emulation.setDeviceMetricsOverride",
+                json!({
+                    "width": vp.width,
+                    "height": vp.height,
+                    "deviceScaleFactor": vp.device_scale_factor,
+                    "mobile": vp.mobile,
+                }),
+            )
+            .await?;
+        }
+        if let Some(geo) = self.geolocation.clone() {
+            self.send_to_target(
+                session_id,
+                "Emulation.setGeolocationOverride",
+                json!({
+                    "latitude": geo.latitude,
+                    "longitude": geo.longitude,
+                    "accuracy": geo.accuracy,
+                }),
+            )
+            .await?;
+        }
         Ok(())
     }
 

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -173,12 +173,11 @@ impl CdpClient {
         self.send_to_target(&session_id, "Runtime.enable", json!({}))
             .await?;
 
+        // Apply any existing blocklist to the new session before storing it.
+        self.apply_network_rules_internal(&session_id).await;
+
         self.persistent_session = Some(session_id);
         self.persistent_target_id = Some(target_id.to_string());
-
-        // Apply any existing blocklist to the new session
-        self.apply_network_rules_internal(&self.persistent_session.clone().unwrap())
-            .await;
         Ok(())
     }
 

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -83,9 +83,10 @@ pub struct CdpClient {
     /// Target ID the persistent session is attached to.
     pub persistent_target_id: Option<String>,
     /// Accumulated network events from the persistent session.
-    pub network_events: Vec<Value>,
+    /// VecDeque so the size cap is O(1) (pop_front) instead of O(N) (Vec front drain).
+    pub network_events: std::collections::VecDeque<Value>,
     /// Accumulated console events from the persistent session.
-    pub console_events: Vec<Value>,
+    pub console_events: std::collections::VecDeque<Value>,
     /// Persistent URL block patterns for `Network.setBlockedURLs`.
     /// Re-applied by `ensure_persistent_session` whenever a new target is attached.
     pub blocklist: Vec<String>,
@@ -155,8 +156,8 @@ impl CdpClient {
             events: std::collections::VecDeque::new(),
             persistent_session: None,
             persistent_target_id: None,
-            network_events: Vec::new(),
-            console_events: Vec::new(),
+            network_events: std::collections::VecDeque::new(),
+            console_events: std::collections::VecDeque::new(),
             blocklist: Vec::new(),
             viewport: None,
             geolocation: None,
@@ -330,12 +331,12 @@ impl CdpClient {
 
     /// Drain accumulated network events from the persistent session.
     pub fn drain_network_events(&mut self) -> Vec<Value> {
-        std::mem::take(&mut self.network_events)
+        std::mem::take(&mut self.network_events).into()
     }
 
     /// Drain accumulated console events from the persistent session.
     pub fn drain_console_events(&mut self) -> Vec<Value> {
-        std::mem::take(&mut self.console_events)
+        std::mem::take(&mut self.console_events).into()
     }
 
     fn push_event(&mut self, event: Value) {
@@ -360,18 +361,16 @@ impl CdpClient {
                 | "Network.responseReceived"
                 | "Network.loadingFinished"
                 | "Network.loadingFailed" => {
-                    self.network_events.push(event);
+                    self.network_events.push_back(event);
                     if self.network_events.len() > MAX_PERSISTENT_EVENTS {
-                        self.network_events
-                            .drain(..self.network_events.len() - MAX_PERSISTENT_EVENTS);
+                        self.network_events.pop_front();
                     }
                     return;
                 }
                 "Runtime.consoleAPICalled" | "Runtime.exceptionThrown" => {
-                    self.console_events.push(event);
+                    self.console_events.push_back(event);
                     if self.console_events.len() > MAX_PERSISTENT_EVENTS {
-                        self.console_events
-                            .drain(..self.console_events.len() - MAX_PERSISTENT_EVENTS);
+                        self.console_events.pop_front();
                     }
                     return;
                 }

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -141,6 +141,27 @@ pub struct TabEmulation {
     pub geolocation: Option<GeolocationOverride>,
 }
 
+impl TabEmulation {
+    /// True when the tab has no overrides of any kind.
+    fn is_empty(&self) -> bool {
+        self.blocklist.is_empty() && self.viewport.is_none() && self.geolocation.is_none()
+    }
+}
+
+/// Stash an outgoing tab's emulation state under its target id so it can be
+/// restored when that tab becomes active again. Empty state is dropped so the
+/// map doesn't accumulate blank entries for every tab ever visited. Pure (no
+/// I/O) — this is the per-tab isolation invariant and is unit-tested below.
+fn stash_tab_emulation(
+    saved: &mut std::collections::HashMap<String, TabEmulation>,
+    target: String,
+    state: TabEmulation,
+) {
+    if !state.is_empty() {
+        saved.insert(target, state);
+    }
+}
+
 impl CdpClient {
     /// Connect to Chrome via WebSocket and return a CDP client.
     pub async fn connect(ws_url: &str) -> Result<Self> {
@@ -195,12 +216,7 @@ impl CdpClient {
                 viewport: self.viewport.take(),
                 geolocation: self.geolocation.take(),
             };
-            if !saved.blocklist.is_empty()
-                || saved.viewport.is_some()
-                || saved.geolocation.is_some()
-            {
-                self.emulation_saved.insert(old_target, saved);
-            }
+            stash_tab_emulation(&mut self.emulation_saved, old_target, saved);
         }
 
         // Detach old session if target changed
@@ -720,9 +736,7 @@ impl CdpClient {
                 // etc.) — real transport error. Log it so the user has a
                 // signal when the partial result is suspicious, then stop.
                 Ok(Err(e)) => {
-                    eprintln!(
-                        "Warning: WebSocket read failed during event collection: {e}"
-                    );
+                    eprintln!("Warning: WebSocket read failed during event collection: {e}");
                     break;
                 }
             }
@@ -847,5 +861,65 @@ mod tests {
         // Malformed - missing targetInfos
         let malformed_resp = json!({});
         assert!(malformed_resp["targetInfos"].as_array().is_none());
+    }
+
+    // Per-tab emulation isolation: the save/restore that `ensure_persistent_session`
+    // performs on target switch. These exercise the pure state logic directly,
+    // without a live CDP connection. They guard the invariant that one tab's
+    // blocklist/overrides never leak into another — the property a side-by-side
+    // two-tab comparison workflow depends on.
+
+    #[test]
+    fn switching_to_fresh_tab_does_not_inherit_blocklist() {
+        let mut saved = std::collections::HashMap::new();
+        // Leaving tab A, which has a block rule: stash it.
+        stash_tab_emulation(
+            &mut saved,
+            "A".to_string(),
+            TabEmulation {
+                blocklist: vec!["*.png".to_string()],
+                ..Default::default()
+            },
+        );
+
+        // Arriving at fresh tab B (no saved state) → clean slate, as
+        // ensure_persistent_session does via `remove(target).unwrap_or_default()`.
+        let b_state = saved.remove("B").unwrap_or_default();
+        assert!(
+            b_state.blocklist.is_empty(),
+            "tab B must not inherit tab A's block rule"
+        );
+        // A's rule is preserved for when we switch back.
+        assert_eq!(saved.get("A").unwrap().blocklist, vec!["*.png".to_string()]);
+    }
+
+    #[test]
+    fn returning_to_tab_restores_and_consumes_its_state() {
+        let mut saved = std::collections::HashMap::new();
+        stash_tab_emulation(
+            &mut saved,
+            "A".to_string(),
+            TabEmulation {
+                blocklist: vec!["*.png".to_string()],
+                ..Default::default()
+            },
+        );
+
+        let restored = saved.remove("A").unwrap_or_default();
+        assert_eq!(restored.blocklist, vec!["*.png".to_string()]);
+        assert!(
+            saved.is_empty(),
+            "the restored entry should be consumed, not duplicated"
+        );
+    }
+
+    #[test]
+    fn empty_tab_state_is_not_stashed() {
+        let mut saved = std::collections::HashMap::new();
+        stash_tab_emulation(&mut saved, "A".to_string(), TabEmulation::default());
+        assert!(
+            !saved.contains_key("A"),
+            "an empty tab must not create a map entry"
+        );
     }
 }

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -269,8 +269,19 @@ impl CdpClient {
         self.viewport = restored.viewport;
         self.geolocation = restored.geolocation;
 
-        self.apply_network_rules_internal(&session_id).await?;
-        self.apply_emulation_internal(&session_id).await?;
+        for res in [
+            self.apply_network_rules_internal(&session_id).await,
+            self.apply_emulation_internal(&session_id).await,
+        ] {
+            if let Err(e) = res {
+                self.persistent_session = None;
+                self.persistent_target_id = None;
+                let _ = self
+                    .send("Target.detachFromTarget", json!({"sessionId": session_id}))
+                    .await;
+                return Err(e);
+            }
+        }
 
         Ok(())
     }

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -269,18 +269,22 @@ impl CdpClient {
         self.viewport = restored.viewport;
         self.geolocation = restored.geolocation;
 
-        for res in [
-            self.apply_network_rules_internal(&session_id).await,
-            self.apply_emulation_internal(&session_id).await,
-        ] {
-            if let Err(e) = res {
-                self.persistent_session = None;
-                self.persistent_target_id = None;
-                let _ = self
-                    .send("Target.detachFromTarget", json!({"sessionId": session_id}))
-                    .await;
-                return Err(e);
-            }
+        if let Err(e) = self.apply_network_rules_internal(&session_id).await {
+            self.persistent_session = None;
+            self.persistent_target_id = None;
+            let _ = self
+                .send("Target.detachFromTarget", json!({"sessionId": session_id}))
+                .await;
+            return Err(e);
+        }
+
+        if let Err(e) = self.apply_emulation_internal(&session_id).await {
+            self.persistent_session = None;
+            self.persistent_target_id = None;
+            let _ = self
+                .send("Target.detachFromTarget", json!({"sessionId": session_id}))
+                .await;
+            return Err(e);
         }
 
         Ok(())

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -89,9 +89,6 @@ pub struct CdpClient {
     /// Persistent URL block patterns for `Network.setBlockedURLs`.
     /// Re-applied by `ensure_persistent_session` whenever a new target is attached.
     pub blocklist: Vec<String>,
-    /// Persistent URL allow patterns. When non-empty, only these URLs are allowed;
-    /// everything else is blocked. Re-applied on session (re)attach.
-    pub allowlist: Vec<String>,
 }
 
 const MAX_BUFFERED_EVENTS: usize = 1000;
@@ -125,7 +122,6 @@ impl CdpClient {
             network_events: Vec::new(),
             console_events: Vec::new(),
             blocklist: Vec::new(),
-            allowlist: Vec::new(),
         })
     }
 
@@ -142,6 +138,11 @@ impl CdpClient {
         if self.persistent_target_id.as_deref() == Some(target_id) {
             return Ok(());
         }
+
+        // Target is changing — discard events accumulated under the previous
+        // target so a later drain under the new page can't return stale events.
+        self.network_events.clear();
+        self.console_events.clear();
 
         // Detach old session if target changed
         if let Some(old_session) = self.persistent_session.take() {
@@ -163,13 +164,14 @@ impl CdpClient {
             .ok_or_else(|| anyhow!("No sessionId in persistent attachToTarget"))?
             .to_string();
 
-        // Enable Network and Runtime domains on persistent session
-        let _ = self
-            .send_to_target(&session_id, "Network.enable", json!({}))
-            .await;
-        let _ = self
-            .send_to_target(&session_id, "Runtime.enable", json!({}))
-            .await;
+        // Enable Network and Runtime domains on the persistent session. If
+        // either fails, bail before marking the session persistent so that
+        // per-command collectors fall back to their own enable instead of
+        // silently draining an uninitialized (always-empty) buffer.
+        self.send_to_target(&session_id, "Network.enable", json!({}))
+            .await?;
+        self.send_to_target(&session_id, "Runtime.enable", json!({}))
+            .await?;
 
         self.persistent_session = Some(session_id);
         self.persistent_target_id = Some(target_id.to_string());
@@ -209,7 +211,24 @@ impl CdpClient {
     }
 
     fn push_event(&mut self, event: Value) {
-        if self.persistent_session.is_some() {
+        // Only route events into the persistent buffers when the event's
+        // sessionId matches the persistent page session (flatten-mode events
+        // are tagged with sessionId). Events from ad-hoc sessions (sw-logs
+        // attach, per-command live sessions) fall through and go into the
+        // general events buffer — otherwise a subsequent page `console` drain
+        // would return extension service worker logs.
+        let from_persistent_session = self
+            .persistent_session
+            .as_deref()
+            .is_some_and(|s| {
+                event
+                    .get("sessionId")
+                    .and_then(|v| v.as_str())
+                    .map(|session_id| session_id == s)
+                    .unwrap_or(false)
+            });
+
+        if from_persistent_session {
             let method = event.get("method").and_then(|v| v.as_str()).unwrap_or("");
             match method {
                 "Network.requestWillBeSent"

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -725,6 +725,10 @@ impl CdpClient {
                 Ok(Ok(text)) => {
                     if let Ok(resp) = serde_json::from_str::<Value>(&text) {
                         if resp.get("method").is_some() {
+                            // Events are routed to persistent session buffers (network_events,
+                            // console_events) AND returned in the `events` vector here.
+                            // Callers using the persistent-session path should drain the
+                            // buffers and ignore this return value to avoid double-processing.
                             self.push_event(resp.clone());
                             events.push(resp);
                         }

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -227,16 +227,13 @@ impl CdpClient {
         // attach, per-command live sessions) fall through and go into the
         // general events buffer — otherwise a subsequent page `console` drain
         // would return extension service worker logs.
-        let from_persistent_session = self
-            .persistent_session
-            .as_deref()
-            .is_some_and(|s| {
-                event
-                    .get("sessionId")
-                    .and_then(|v| v.as_str())
-                    .map(|session_id| session_id == s)
-                    .unwrap_or(false)
-            });
+        let from_persistent_session = self.persistent_session.as_deref().is_some_and(|s| {
+            event
+                .get("sessionId")
+                .and_then(|v| v.as_str())
+                .map(|session_id| session_id == s)
+                .unwrap_or(false)
+        });
 
         if from_persistent_session {
             let method = event.get("method").and_then(|v| v.as_str()).unwrap_or("");
@@ -247,14 +244,16 @@ impl CdpClient {
                 | "Network.loadingFailed" => {
                     self.network_events.push(event);
                     if self.network_events.len() > MAX_PERSISTENT_EVENTS {
-                        self.network_events.drain(..self.network_events.len() - MAX_PERSISTENT_EVENTS);
+                        self.network_events
+                            .drain(..self.network_events.len() - MAX_PERSISTENT_EVENTS);
                     }
                     return;
                 }
                 "Runtime.consoleAPICalled" | "Runtime.exceptionThrown" => {
                     self.console_events.push(event);
                     if self.console_events.len() > MAX_PERSISTENT_EVENTS {
-                        self.console_events.drain(..self.console_events.len() - MAX_PERSISTENT_EVENTS);
+                        self.console_events
+                            .drain(..self.console_events.len() - MAX_PERSISTENT_EVENTS);
                     }
                     return;
                 }
@@ -434,7 +433,11 @@ impl CdpClient {
                 }
             }) {
                 if let Some(resp) = self.events.remove(idx) {
-                    let method = resp.get("method").and_then(|v| v.as_str()).unwrap_or_default().to_string();
+                    let method = resp
+                        .get("method")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
                     return Ok((method, resp.get("params").cloned().unwrap_or(Value::Null)));
                 }
             }
@@ -578,8 +581,7 @@ impl CdpClient {
     /// session buffers when active to avoid duplicates.
     pub async fn read_events_for(&mut self, duration_ms: u64) -> Result<Vec<Value>> {
         let mut events: Vec<Value> = self.events.drain(..).collect();
-        let deadline =
-            tokio::time::Instant::now() + std::time::Duration::from_millis(duration_ms);
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(duration_ms);
 
         loop {
             let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -78,9 +78,24 @@ pub struct CdpClient {
     pub dialog_action: Option<String>,
     /// Buffer for storing unhandled events (e.g., navigation events)
     pub events: std::collections::VecDeque<Value>,
+    /// Persistent CDP session for continuous event collection across commands.
+    pub persistent_session: Option<String>,
+    /// Target ID the persistent session is attached to.
+    pub persistent_target_id: Option<String>,
+    /// Accumulated network events from the persistent session.
+    pub network_events: Vec<Value>,
+    /// Accumulated console events from the persistent session.
+    pub console_events: Vec<Value>,
+    /// Persistent URL block patterns for `Network.setBlockedURLs`.
+    /// Re-applied by `ensure_persistent_session` whenever a new target is attached.
+    pub blocklist: Vec<String>,
+    /// Persistent URL allow patterns. When non-empty, only these URLs are allowed;
+    /// everything else is blocked. Re-applied on session (re)attach.
+    pub allowlist: Vec<String>,
 }
 
 const MAX_BUFFERED_EVENTS: usize = 1000;
+const MAX_PERSISTENT_EVENTS: usize = 5000;
 
 /// Metadata for a Chrome target (page, worker, etc.).
 #[derive(Debug, Clone)]
@@ -105,6 +120,12 @@ impl CdpClient {
             next_id: 1,
             dialog_action: None,
             events: std::collections::VecDeque::new(),
+            persistent_session: None,
+            persistent_target_id: None,
+            network_events: Vec::new(),
+            console_events: Vec::new(),
+            blocklist: Vec::new(),
+            allowlist: Vec::new(),
         })
     }
 
@@ -113,7 +134,104 @@ impl CdpClient {
         self.events.clear();
     }
 
+    /// Ensure a persistent CDP session is attached to the given target for continuous
+    /// event collection (Network + Console). If the target has changed, detaches
+    /// the old session and attaches to the new one.
+    pub async fn ensure_persistent_session(&mut self, target_id: &str) -> Result<()> {
+        // Already attached to this target
+        if self.persistent_target_id.as_deref() == Some(target_id) {
+            return Ok(());
+        }
+
+        // Detach old session if target changed
+        if let Some(old_session) = self.persistent_session.take() {
+            let _ = self
+                .send("Target.detachFromTarget", json!({"sessionId": old_session}))
+                .await;
+            self.persistent_target_id = None;
+        }
+
+        // Attach new persistent session
+        let result = self
+            .send(
+                "Target.attachToTarget",
+                json!({"targetId": target_id, "flatten": true}),
+            )
+            .await?;
+        let session_id = result["sessionId"]
+            .as_str()
+            .ok_or_else(|| anyhow!("No sessionId in persistent attachToTarget"))?
+            .to_string();
+
+        // Enable Network and Runtime domains on persistent session
+        let _ = self
+            .send_to_target(&session_id, "Network.enable", json!({}))
+            .await;
+        let _ = self
+            .send_to_target(&session_id, "Runtime.enable", json!({}))
+            .await;
+
+        self.persistent_session = Some(session_id);
+        self.persistent_target_id = Some(target_id.to_string());
+
+        // Apply any existing blocklist to the new session
+        self.apply_network_rules_internal(&self.persistent_session.clone().unwrap())
+            .await;
+        Ok(())
+    }
+
+    /// Apply the daemon's current `blocklist` to the persistent session via
+    /// `Network.setBlockedURLs`. Patterns are Chrome-style globs (e.g. `*.png`).
+    pub async fn apply_network_rules(&mut self) {
+        if let Some(ref session) = self.persistent_session.clone() {
+            self.apply_network_rules_internal(session).await;
+        }
+    }
+
+    async fn apply_network_rules_internal(&mut self, session_id: &str) {
+        let _ = self
+            .send_to_target(
+                session_id,
+                "Network.setBlockedURLs",
+                json!({"urls": self.blocklist}),
+            )
+            .await;
+    }
+
+    /// Drain accumulated network events from the persistent session.
+    pub fn drain_network_events(&mut self) -> Vec<Value> {
+        std::mem::take(&mut self.network_events)
+    }
+
+    /// Drain accumulated console events from the persistent session.
+    pub fn drain_console_events(&mut self) -> Vec<Value> {
+        std::mem::take(&mut self.console_events)
+    }
+
     fn push_event(&mut self, event: Value) {
+        if self.persistent_session.is_some() {
+            let method = event.get("method").and_then(|v| v.as_str()).unwrap_or("");
+            match method {
+                "Network.requestWillBeSent"
+                | "Network.responseReceived"
+                | "Network.loadingFinished"
+                | "Network.loadingFailed" => {
+                    self.network_events.push(event);
+                    if self.network_events.len() > MAX_PERSISTENT_EVENTS {
+                        self.network_events.drain(..self.network_events.len() - MAX_PERSISTENT_EVENTS);
+                    }
+                    return;
+                }
+                "Runtime.consoleAPICalled" | "Runtime.exceptionThrown" => {
+                    self.console_events.push(event);
+                    if self.console_events.len() > MAX_PERSISTENT_EVENTS {
+                        self.console_events.drain(..self.console_events.len() - MAX_PERSISTENT_EVENTS);
+                    }
+                    return;
+                }
+                _ => {}
+            }
+        }
         Self::push_to_buffer(&mut self.events, event);
     }
 
@@ -356,6 +474,28 @@ impl CdpClient {
         Ok(pages)
     }
 
+    /// List all targets (pages, workers, etc.).
+    pub async fn get_all_targets(&mut self) -> Result<Vec<TargetInfo>> {
+        let result = self.send("Target.getTargets", json!({})).await?;
+        let targets = result["targetInfos"].as_array().ok_or_else(|| {
+            anyhow!("Malformed Target.getTargets response: missing 'targetInfos' array")
+        })?;
+
+        let mut all = Vec::new();
+        for t in targets {
+            all.push(TargetInfo {
+                target_id: t["targetId"]
+                    .as_str()
+                    .ok_or_else(|| anyhow!("Malformed TargetInfo: missing 'targetId'"))?
+                    .to_string(),
+                title: t["title"].as_str().unwrap_or("").to_string(),
+                url: t["url"].as_str().unwrap_or("").to_string(),
+                target_type: t["type"].as_str().unwrap_or("").to_string(),
+            });
+        }
+        Ok(all)
+    }
+
     /// Attach to a target and return the session ID for subsequent commands.
     pub async fn attach_to_target(&mut self, target_id: &str) -> Result<String> {
         let result = self
@@ -400,6 +540,37 @@ impl CdpClient {
         self.send("Target.closeTarget", json!({"targetId": target_id}))
             .await?;
         Ok(())
+    }
+
+    /// Collect CDP events for a given duration (milliseconds).
+    ///
+    /// Drains any already-buffered events first, then reads from the WebSocket
+    /// until the timeout expires. Events are also routed through persistent
+    /// session buffers when active to avoid duplicates.
+    pub async fn read_events_for(&mut self, duration_ms: u64) -> Result<Vec<Value>> {
+        let mut events: Vec<Value> = self.events.drain(..).collect();
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_millis(duration_ms);
+
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            match tokio::time::timeout(remaining, self.read_text()).await {
+                Ok(Ok(text)) => {
+                    if let Ok(resp) = serde_json::from_str::<Value>(&text) {
+                        if resp.get("method").is_some() {
+                            self.push_event(resp.clone());
+                            events.push(resp);
+                        }
+                    }
+                }
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+
+        Ok(events)
     }
 
     /// Get the current page URL via JavaScript evaluation.

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -200,7 +200,10 @@ impl CdpClient {
         }
     }
 
-    async fn apply_network_rules_internal(&mut self, session_id: &str) {
+    /// Apply the current `blocklist` to a specific session via
+    /// `Network.setBlockedURLs`. Used for both the persistent session and
+    /// fallback per-command sessions (when the persistent one is unavailable).
+    pub(crate) async fn apply_network_rules_internal(&mut self, session_id: &str) {
         let _ = self
             .send_to_target(
                 session_id,

--- a/src/cdp.rs
+++ b/src/cdp.rs
@@ -347,6 +347,8 @@ impl CdpClient {
     /// `Network.setBlockedURLs`. Used for both the persistent session and
     /// fallback per-command sessions (when the persistent one is unavailable).
     pub(crate) async fn apply_network_rules_internal(&mut self, session_id: &str) -> Result<()> {
+        self.send_to_target(session_id, "Network.enable", json!({}))
+            .await?;
         self.send_to_target(
             session_id,
             "Network.setBlockedURLs",
@@ -743,7 +745,13 @@ impl CdpClient {
                             // Network/Runtime events to the generic `self.events` buffer.
                             // This prevents them from being stashed and then returned
                             // again in a subsequent drain (double-processing).
-                            if self.persistent_session.is_some() {
+                            let is_persistent_event = self.persistent_session.as_deref().is_some_and(|s| {
+                                resp.get("sessionId")
+                                    .and_then(|v| v.as_str())
+                                    .map(|session_id| session_id == s)
+                                    .unwrap_or(false)
+                            });
+                            if is_persistent_event {
                                 self.push_event(resp.clone());
                             } else if !method.starts_with("Network.") && !method.starts_with("Runtime.") {
                                 self.push_event(resp.clone());

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -1,0 +1,128 @@
+use anyhow::Result;
+use serde_json::json;
+use std::fmt::Write;
+
+use crate::cdp::CdpClient;
+use crate::format::{format_structured, OutputFormat};
+use crate::result::CommandResult;
+
+pub async fn collect_console(
+    client: &mut CdpClient,
+    session_id: &str,
+    duration_ms: u64,
+    type_filter: Vec<String>,
+    format: OutputFormat,
+) -> Result<CommandResult> {
+    let events = if duration_ms > 0 {
+        // Live mode: the persistent session already has Runtime enabled,
+        // so we skip enabling it on the command's own session to avoid
+        // duplicate events from two sessions both receiving the same messages.
+        if client.persistent_session.is_none() {
+            client
+                .send_to_target(session_id, "Runtime.enable", json!({}))
+                .await?;
+        }
+        let events = client.read_events_for(duration_ms).await?;
+        if client.persistent_session.is_none() {
+            let _ = client
+                .send_to_target(session_id, "Runtime.disable", json!({}))
+                .await;
+        }
+        events
+    } else {
+        // Drain mode: return accumulated events from persistent session
+        client.drain_console_events()
+    };
+
+    let messages = process_console_events(&events, &type_filter);
+
+    format_console_output(&messages, format)
+}
+
+fn process_console_events(events: &[serde_json::Value], type_filter: &[String]) -> Vec<serde_json::Value> {
+    let filter_set: Option<std::collections::HashSet<&str>> = if type_filter.is_empty() {
+        None
+    } else {
+        Some(type_filter.iter().map(|s| s.as_str()).collect())
+    };
+
+    let mut messages = Vec::new();
+
+    for event in events {
+        let method = event["method"].as_str().unwrap_or("");
+        let params = &event["params"];
+
+        match method {
+            "Runtime.consoleAPICalled" => {
+                let msg_type = params["type"].as_str().unwrap_or("log");
+                if let Some(ref set) = filter_set {
+                    if !set.contains(msg_type) {
+                        continue;
+                    }
+                }
+                let args: Vec<String> = params["args"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|arg| {
+                                arg["value"]
+                                    .as_str()
+                                    .or_else(|| arg["description"].as_str())
+                                    .unwrap_or("<object>")
+                                    .to_string()
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let text = args.join(" ");
+                let timestamp = params["timestamp"].as_f64().unwrap_or(0.0);
+
+                messages.push(json!({
+                    "type": msg_type,
+                    "text": text,
+                    "timestamp": timestamp,
+                }));
+            }
+            "Runtime.exceptionThrown" => {
+                if let Some(ref set) = filter_set {
+                    if !set.contains("exception") && !set.contains("error") {
+                        continue;
+                    }
+                }
+                let details = &params["exceptionDetails"];
+                let text = details["text"].as_str().unwrap_or("Unknown error");
+                let description = details["exception"]["description"]
+                    .as_str()
+                    .unwrap_or(text);
+                let timestamp = params["timestamp"].as_f64().unwrap_or(0.0);
+
+                messages.push(json!({
+                    "type": "exception",
+                    "text": description,
+                    "timestamp": timestamp,
+                }));
+            }
+            _ => {}
+        }
+    }
+
+    messages
+}
+
+fn format_console_output(messages: &[serde_json::Value], format: OutputFormat) -> Result<CommandResult> {
+    if format.is_text() {
+        if messages.is_empty() {
+            return Ok(CommandResult::output("No console messages collected.".to_string()));
+        }
+        let mut out = String::new();
+        for msg in messages {
+            let msg_type = msg["type"].as_str().unwrap_or("?");
+            let text = msg["text"].as_str().unwrap_or("");
+            writeln!(out, "[{msg_type}] {text}").unwrap();
+        }
+        Ok(CommandResult::output(out))
+    } else {
+        let value = serde_json::to_value(messages)?;
+        Ok(CommandResult::output(format_structured(&value, format)?))
+    }
+}

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -67,12 +67,13 @@ fn process_console_events(events: &[serde_json::Value], type_filter: &[String]) 
                     .as_array()
                     .map(|arr| {
                         arr.iter()
-                            .map(|arg| {
-                                arg["value"]
-                                    .as_str()
-                                    .or_else(|| arg["description"].as_str())
-                                    .unwrap_or("<object>")
-                                    .to_string()
+                            .map(|arg| match arg.get("value") {
+                                // String primitives: emit the raw text (no quotes).
+                                Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
+                                // Other primitives (number, bool, null): stringify directly.
+                                Some(v) => v.to_string(),
+                                // Objects have no `value` — fall back to their description.
+                                None => arg["description"].as_str().unwrap_or("<object>").to_string(),
                             })
                             .collect()
                     })

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -13,25 +13,28 @@ pub async fn collect_console(
     type_filter: Vec<String>,
     format: OutputFormat,
 ) -> Result<CommandResult> {
-    let events = if duration_ms > 0 {
-        // Live mode: the persistent session already has Runtime enabled,
-        // so we skip enabling it on the command's own session to avoid
-        // duplicate events from two sessions both receiving the same messages.
-        if client.persistent_session.is_none() {
-            client
-                .send_to_target(session_id, "Runtime.enable", json!({}))
-                .await?;
-        }
-        let events_result = client.read_events_for(duration_ms).await;
-        if client.persistent_session.is_none() {
-            let _ = client
-                .send_to_target(session_id, "Runtime.disable", json!({}))
-                .await;
-        }
-        events_result?
-    } else {
-        // Drain mode: return accumulated events from persistent session
+    let events = if duration_ms == 0 {
+        // Drain mode: return accumulated events from the persistent session.
         client.drain_console_events()
+    } else if client.persistent_session.is_some() {
+        // Live mode, daemon: the persistent session already has Runtime enabled
+        // and push_event accumulates its events into console_events. Read for the
+        // window so they land in the buffer, then drain the buffer as the single
+        // source of truth. Draining also consumes them, so a later drain can't
+        // repeat them (read_events_for's own return value would double-count).
+        client.read_events_for(duration_ms).await?;
+        client.drain_console_events()
+    } else {
+        // Live mode, direct/fallback: no persistent buffer. Enable Runtime on our
+        // own session, collect for the window, disable, and return what we read.
+        client
+            .send_to_target(session_id, "Runtime.enable", json!({}))
+            .await?;
+        let events_result = client.read_events_for(duration_ms).await;
+        let _ = client
+            .send_to_target(session_id, "Runtime.disable", json!({}))
+            .await;
+        events_result?
     };
 
     let messages = process_console_events(&events, &type_filter);

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -22,13 +22,13 @@ pub async fn collect_console(
                 .send_to_target(session_id, "Runtime.enable", json!({}))
                 .await?;
         }
-        let events = client.read_events_for(duration_ms).await?;
+        let events_result = client.read_events_for(duration_ms).await;
         if client.persistent_session.is_none() {
             let _ = client
                 .send_to_target(session_id, "Runtime.disable", json!({}))
                 .await;
         }
-        events
+        events_result?
     } else {
         // Drain mode: return accumulated events from persistent session
         client.drain_console_events()
@@ -124,5 +124,102 @@ fn format_console_output(messages: &[serde_json::Value], format: OutputFormat) -
     } else {
         let value = serde_json::to_value(messages)?;
         Ok(CommandResult::output(format_structured(&value, format)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_process_console_events_joins_args() {
+        let events = vec![json!({
+            "method": "Runtime.consoleAPICalled",
+            "params": {
+                "type": "log",
+                "args": [
+                    {"type": "string", "value": "hello"},
+                    {"type": "number", "value": "42"}
+                ],
+                "timestamp": 1000.0
+            }
+        })];
+        let out = process_console_events(&events, &[]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["type"], "log");
+        assert_eq!(out[0]["text"], "hello 42");
+        assert_eq!(out[0]["timestamp"], 1000.0);
+    }
+
+    #[test]
+    fn test_process_console_events_uses_description_when_value_missing() {
+        let events = vec![json!({
+            "method": "Runtime.consoleAPICalled",
+            "params": {
+                "type": "log",
+                "args": [
+                    {"type": "object", "description": "Object"}
+                ],
+                "timestamp": 0.0
+            }
+        })];
+        let out = process_console_events(&events, &[]);
+        assert_eq!(out[0]["text"], "Object");
+    }
+
+    #[test]
+    fn test_process_console_events_exception() {
+        let events = vec![json!({
+            "method": "Runtime.exceptionThrown",
+            "params": {
+                "exceptionDetails": {
+                    "text": "TypeError",
+                    "exception": {"description": "Cannot read property 'x' of null"}
+                },
+                "timestamp": 2000.0
+            }
+        })];
+        let out = process_console_events(&events, &[]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["type"], "exception");
+        assert_eq!(out[0]["text"], "Cannot read property 'x' of null");
+    }
+
+    #[test]
+    fn test_process_console_events_type_filter_excludes() {
+        let events = vec![
+            json!({"method": "Runtime.consoleAPICalled", "params": {"type": "log", "args": [{"value": "skipped"}], "timestamp": 0.0}}),
+            json!({"method": "Runtime.consoleAPICalled", "params": {"type": "error", "args": [{"value": "kept"}], "timestamp": 0.0}}),
+        ];
+        let filter = vec!["error".to_string()];
+        let out = process_console_events(&events, &filter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["text"], "kept");
+    }
+
+    #[test]
+    fn test_process_console_events_error_filter_includes_exceptions() {
+        let events = vec![json!({
+            "method": "Runtime.exceptionThrown",
+            "params": {
+                "exceptionDetails": {"text": "oops", "exception": {}},
+                "timestamp": 0.0
+            }
+        })];
+        // "error" filter should include exceptions
+        let filter = vec!["error".to_string()];
+        let out = process_console_events(&events, &filter);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn test_process_console_events_ignores_unknown_methods() {
+        let events = vec![json!({
+            "method": "Network.requestWillBeSent",
+            "params": {}
+        })];
+        let out = process_console_events(&events, &[]);
+        assert!(out.is_empty());
     }
 }

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -81,25 +81,8 @@ fn process_console_events(
                         continue;
                     }
                 }
-                let args: Vec<String> = params["args"]
-                    .as_array()
-                    .map(|arr| {
-                        arr.iter()
-                            .map(|arg| match arg.get("value") {
-                                // String primitives: emit the raw text (no quotes).
-                                Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
-                                // Other primitives (number, bool, null): stringify directly.
-                                Some(v) => v.to_string(),
-                                // Objects have no `value` — fall back to their description.
-                                None => arg["description"]
-                                    .as_str()
-                                    .unwrap_or("<object>")
-                                    .to_string(),
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let text = args.join(" ");
+                let args = params["args"].as_array().map(|v| v.as_slice()).unwrap_or(&[]);
+                let text = crate::cdp::join_console_args(args);
                 let timestamp = params["timestamp"].as_f64().unwrap_or(0.0);
 
                 messages.push(json!({

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -42,7 +42,10 @@ pub async fn collect_console(
     format_console_output(&messages, format)
 }
 
-fn process_console_events(events: &[serde_json::Value], type_filter: &[String]) -> Vec<serde_json::Value> {
+fn process_console_events(
+    events: &[serde_json::Value],
+    type_filter: &[String],
+) -> Vec<serde_json::Value> {
     let filter_set: Option<std::collections::HashSet<&str>> = if type_filter.is_empty() {
         None
     } else {
@@ -73,7 +76,10 @@ fn process_console_events(events: &[serde_json::Value], type_filter: &[String]) 
                                 // Other primitives (number, bool, null): stringify directly.
                                 Some(v) => v.to_string(),
                                 // Objects have no `value` — fall back to their description.
-                                None => arg["description"].as_str().unwrap_or("<object>").to_string(),
+                                None => arg["description"]
+                                    .as_str()
+                                    .unwrap_or("<object>")
+                                    .to_string(),
                             })
                             .collect()
                     })
@@ -95,9 +101,7 @@ fn process_console_events(events: &[serde_json::Value], type_filter: &[String]) 
                 }
                 let details = &params["exceptionDetails"];
                 let text = details["text"].as_str().unwrap_or("Unknown error");
-                let description = details["exception"]["description"]
-                    .as_str()
-                    .unwrap_or(text);
+                let description = details["exception"]["description"].as_str().unwrap_or(text);
                 let timestamp = params["timestamp"].as_f64().unwrap_or(0.0);
 
                 messages.push(json!({
@@ -113,10 +117,15 @@ fn process_console_events(events: &[serde_json::Value], type_filter: &[String]) 
     messages
 }
 
-fn format_console_output(messages: &[serde_json::Value], format: OutputFormat) -> Result<CommandResult> {
+fn format_console_output(
+    messages: &[serde_json::Value],
+    format: OutputFormat,
+) -> Result<CommandResult> {
     if format.is_text() {
         if messages.is_empty() {
-            return Ok(CommandResult::output("No console messages collected.".to_string()));
+            return Ok(CommandResult::output(
+                "No console messages collected.".to_string(),
+            ));
         }
         let mut out = String::new();
         for msg in messages {

--- a/src/commands/console.rs
+++ b/src/commands/console.rs
@@ -46,10 +46,25 @@ fn process_console_events(
     events: &[serde_json::Value],
     type_filter: &[String],
 ) -> Vec<serde_json::Value> {
-    let filter_set: Option<std::collections::HashSet<&str>> = if type_filter.is_empty() {
+    // Match case-insensitively and accept the common "warn" shorthand for the
+    // CDP type "warning" (mirrors `console.warn`). CDP console types are already
+    // lowercase, so this mainly hardens against odd-cased / shorthand input.
+    let filter_set: Option<std::collections::HashSet<String>> = if type_filter.is_empty() {
         None
     } else {
-        Some(type_filter.iter().map(|s| s.as_str()).collect())
+        Some(
+            type_filter
+                .iter()
+                .map(|s| {
+                    let s = s.to_lowercase();
+                    if s == "warn" {
+                        "warning".to_string()
+                    } else {
+                        s
+                    }
+                })
+                .collect(),
+        )
     };
 
     let mut messages = Vec::new();
@@ -62,7 +77,7 @@ fn process_console_events(
             "Runtime.consoleAPICalled" => {
                 let msg_type = params["type"].as_str().unwrap_or("log");
                 if let Some(ref set) = filter_set {
-                    if !set.contains(msg_type) {
+                    if !set.contains(&msg_type.to_lowercase()) {
                         continue;
                     }
                 }
@@ -95,6 +110,8 @@ fn process_console_events(
             }
             "Runtime.exceptionThrown" => {
                 if let Some(ref set) = filter_set {
+                    // `set` holds lowercase types (see filter_set), so these
+                    // literals must stay lowercase to match.
                     if !set.contains("exception") && !set.contains("error") {
                         continue;
                     }
@@ -207,6 +224,18 @@ mod tests {
         ];
         let filter = vec!["error".to_string()];
         let out = process_console_events(&events, &filter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["text"], "kept");
+    }
+
+    #[test]
+    fn test_process_console_events_type_filter_warn_alias_and_case() {
+        let events = vec![
+            json!({"method": "Runtime.consoleAPICalled", "params": {"type": "warning", "args": [{"value": "kept"}], "timestamp": 0.0}}),
+            json!({"method": "Runtime.consoleAPICalled", "params": {"type": "log", "args": [{"value": "skipped"}], "timestamp": 0.0}}),
+        ];
+        // "warn" is an alias for the CDP type "warning"; matching is case-insensitive.
+        let out = process_console_events(&events, &vec!["WARN".to_string()]);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0]["text"], "kept");
     }

--- a/src/commands/emulation.rs
+++ b/src/commands/emulation.rs
@@ -14,6 +14,14 @@ pub struct EmulateParams {
     pub clear_viewport: bool,
     pub clear_geolocation: bool,
     pub clear_all: bool,
+    /// Patterns to add to the daemon's network blocklist (`*.png`, `*.gif`, etc.).
+    pub block_url: Vec<String>,
+    /// Patterns to remove from the daemon's network blocklist (effectively allowing them).
+    pub allow_url: Vec<String>,
+    /// Clear the entire network blocklist.
+    pub clear_blocks: bool,
+    /// Clear all blocked patterns (alias for clear_blocks — present for symmetry).
+    pub clear_allows: bool,
 }
 
 impl EmulateParams {
@@ -50,6 +58,10 @@ impl EmulateParams {
             || self.clear_all
             || self.clear_viewport
             || self.clear_geolocation
+            || !self.block_url.is_empty()
+            || !self.allow_url.is_empty()
+            || self.clear_blocks
+            || self.clear_allows
     }
 }
 
@@ -60,6 +72,46 @@ pub async fn emulate(
     params: EmulateParams,
 ) -> Result<CommandResult> {
     let mut actions = Vec::new();
+
+    // 0. Handle network blocklist (applied to the persistent session, not the
+    //    per-command session — so the blocklist survives across commands/targets).
+    let network_changed = !params.block_url.is_empty()
+        || !params.allow_url.is_empty()
+        || params.clear_blocks
+        || params.clear_allows
+        || params.clear_all;
+
+    if params.clear_all || params.clear_blocks || params.clear_allows {
+        client.blocklist.clear();
+        client.allowlist.clear();
+        actions.push("Network blocks cleared".to_string());
+    }
+
+    for pattern in &params.block_url {
+        if !client.blocklist.contains(pattern) {
+            client.blocklist.push(pattern.clone());
+        }
+    }
+    if !params.block_url.is_empty() {
+        actions.push(format!(
+            "Blocked URLs: {}",
+            params.block_url.join(", ")
+        ));
+    }
+
+    for pattern in &params.allow_url {
+        client.blocklist.retain(|p| p != pattern);
+    }
+    if !params.allow_url.is_empty() {
+        actions.push(format!(
+            "Allowed URLs: {}",
+            params.allow_url.join(", ")
+        ));
+    }
+
+    if network_changed {
+        client.apply_network_rules().await;
+    }
 
     // 1. Handle clearing
     if params.clear_all || params.clear_viewport {
@@ -135,9 +187,26 @@ pub async fn emulate(
         actions.push(format!("Geolocation set to {}, {} (acc: {}m)", lat, lon, acc));
     }
 
-    // 4. If no specific action taken, return error (getters removed due to CDP limitations)
+    // 4. If no specific action taken, show current overrides
     if actions.is_empty() {
-        anyhow::bail!("No emulation action specified (use --viewport, --geolocation, or --clear flags)");
+        let mut out = String::new();
+        if client.blocklist.is_empty() && client.allowlist.is_empty() {
+            out.push_str("No emulation overrides active.\n");
+        } else {
+            if !client.blocklist.is_empty() {
+                out.push_str("Blocked URLs:\n");
+                for p in &client.blocklist {
+                    out.push_str(&format!("  {p}\n"));
+                }
+            }
+            if !client.allowlist.is_empty() {
+                out.push_str("Allowed URLs:\n");
+                for p in &client.allowlist {
+                    out.push_str(&format!("  {p}\n"));
+                }
+            }
+        }
+        return Ok(CommandResult::output(out.trim_end().to_string()));
     }
 
     Ok(CommandResult::output(actions.join(", ")))

--- a/src/commands/emulation.rs
+++ b/src/commands/emulation.rs
@@ -102,7 +102,7 @@ pub async fn emulate(
     }
 
     if network_changed {
-        client.apply_network_rules().await;
+        client.apply_network_rules().await?;
     }
 
     // 1. Handle clearing

--- a/src/commands/emulation.rs
+++ b/src/commands/emulation.rs
@@ -88,10 +88,7 @@ pub async fn emulate(
         }
     }
     if !params.block_url.is_empty() {
-        actions.push(format!(
-            "Blocked URLs: {}",
-            params.block_url.join(", ")
-        ));
+        actions.push(format!("Blocked URLs: {}", params.block_url.join(", ")));
     }
 
     for pattern in &params.unblock_url {
@@ -111,7 +108,11 @@ pub async fn emulate(
     // 1. Handle clearing
     if params.clear_all || params.clear_viewport {
         client
-            .send_to_target(session_id, "Emulation.clearDeviceMetricsOverride", json!({}))
+            .send_to_target(
+                session_id,
+                "Emulation.clearDeviceMetricsOverride",
+                json!({}),
+            )
             .await?;
         actions.push("Viewport cleared".to_string());
     }
@@ -130,8 +131,14 @@ pub async fn emulate(
         if parts.len() != 2 {
             anyhow::bail!("Viewport must be in WxH format (e.g. 1280x720)");
         }
-        let w: u32 = parts[0].trim().parse().map_err(|_| anyhow!("Invalid width: {}", parts[0]))?;
-        let h: u32 = parts[1].trim().parse().map_err(|_| anyhow!("Invalid height: {}", parts[1]))?;
+        let w: u32 = parts[0]
+            .trim()
+            .parse()
+            .map_err(|_| anyhow!("Invalid width: {}", parts[0]))?;
+        let h: u32 = parts[1]
+            .trim()
+            .parse()
+            .map_err(|_| anyhow!("Invalid height: {}", parts[1]))?;
         if w == 0 {
             anyhow::bail!("Invalid width: {} (must be > 0)", w);
         }
@@ -152,7 +159,10 @@ pub async fn emulate(
                 }),
             )
             .await?;
-        actions.push(format!("Viewport set to {}x{} (scale: {}, mobile: {})", w, h, dsf, params.mobile));
+        actions.push(format!(
+            "Viewport set to {}x{} (scale: {}, mobile: {})",
+            w, h, dsf, params.mobile
+        ));
     }
 
     // 3. Handle setting geolocation
@@ -161,8 +171,14 @@ pub async fn emulate(
         if parts.len() != 2 {
             anyhow::bail!("Geolocation must be in lat,lon format (e.g. 37.77,-122.41)");
         }
-        let lat: f64 = parts[0].trim().parse().map_err(|_| anyhow!("Invalid latitude: {}", parts[0]))?;
-        let lon: f64 = parts[1].trim().parse().map_err(|_| anyhow!("Invalid longitude: {}", parts[1]))?;
+        let lat: f64 = parts[0]
+            .trim()
+            .parse()
+            .map_err(|_| anyhow!("Invalid latitude: {}", parts[0]))?;
+        let lon: f64 = parts[1]
+            .trim()
+            .parse()
+            .map_err(|_| anyhow!("Invalid longitude: {}", parts[1]))?;
         let acc = params.accuracy.unwrap_or(100.0);
 
         if !(-90.0..=90.0).contains(&lat) {
@@ -179,7 +195,10 @@ pub async fn emulate(
                 json!({ "latitude": lat, "longitude": lon, "accuracy": acc }),
             )
             .await?;
-        actions.push(format!("Geolocation set to {}, {} (acc: {}m)", lat, lon, acc));
+        actions.push(format!(
+            "Geolocation set to {}, {} (acc: {}m)",
+            lat, lon, acc
+        ));
     }
 
     // 4. If no specific action taken, show current overrides

--- a/src/commands/emulation.rs
+++ b/src/commands/emulation.rs
@@ -102,7 +102,13 @@ pub async fn emulate(
     }
 
     if network_changed {
-        client.apply_network_rules().await?;
+        // Apply to persistent session if available; otherwise fall back to the
+        // command's session (e.g., direct mode or degraded daemon path).
+        if client.persistent_session.is_some() {
+            client.apply_network_rules().await?;
+        } else {
+            client.apply_network_rules_internal(session_id).await?;
+        }
     }
 
     // 1. Handle clearing

--- a/src/commands/emulation.rs
+++ b/src/commands/emulation.rs
@@ -16,12 +16,10 @@ pub struct EmulateParams {
     pub clear_all: bool,
     /// Patterns to add to the daemon's network blocklist (`*.png`, `*.gif`, etc.).
     pub block_url: Vec<String>,
-    /// Patterns to remove from the daemon's network blocklist (effectively allowing them).
-    pub allow_url: Vec<String>,
+    /// Patterns to remove from the daemon's network blocklist (un-block them).
+    pub unblock_url: Vec<String>,
     /// Clear the entire network blocklist.
     pub clear_blocks: bool,
-    /// Clear all blocked patterns (alias for clear_blocks — present for symmetry).
-    pub clear_allows: bool,
 }
 
 impl EmulateParams {
@@ -59,9 +57,8 @@ impl EmulateParams {
             || self.clear_viewport
             || self.clear_geolocation
             || !self.block_url.is_empty()
-            || !self.allow_url.is_empty()
+            || !self.unblock_url.is_empty()
             || self.clear_blocks
-            || self.clear_allows
     }
 }
 
@@ -76,14 +73,12 @@ pub async fn emulate(
     // 0. Handle network blocklist (applied to the persistent session, not the
     //    per-command session — so the blocklist survives across commands/targets).
     let network_changed = !params.block_url.is_empty()
-        || !params.allow_url.is_empty()
+        || !params.unblock_url.is_empty()
         || params.clear_blocks
-        || params.clear_allows
         || params.clear_all;
 
-    if params.clear_all || params.clear_blocks || params.clear_allows {
+    if params.clear_all || params.clear_blocks {
         client.blocklist.clear();
-        client.allowlist.clear();
         actions.push("Network blocks cleared".to_string());
     }
 
@@ -99,13 +94,13 @@ pub async fn emulate(
         ));
     }
 
-    for pattern in &params.allow_url {
+    for pattern in &params.unblock_url {
         client.blocklist.retain(|p| p != pattern);
     }
-    if !params.allow_url.is_empty() {
+    if !params.unblock_url.is_empty() {
         actions.push(format!(
-            "Allowed URLs: {}",
-            params.allow_url.join(", ")
+            "Un-blocked URLs: {}",
+            params.unblock_url.join(", ")
         ));
     }
 
@@ -190,20 +185,12 @@ pub async fn emulate(
     // 4. If no specific action taken, show current overrides
     if actions.is_empty() {
         let mut out = String::new();
-        if client.blocklist.is_empty() && client.allowlist.is_empty() {
+        if client.blocklist.is_empty() {
             out.push_str("No emulation overrides active.\n");
         } else {
-            if !client.blocklist.is_empty() {
-                out.push_str("Blocked URLs:\n");
-                for p in &client.blocklist {
-                    out.push_str(&format!("  {p}\n"));
-                }
-            }
-            if !client.allowlist.is_empty() {
-                out.push_str("Allowed URLs:\n");
-                for p in &client.allowlist {
-                    out.push_str(&format!("  {p}\n"));
-                }
+            out.push_str("Blocked URLs:\n");
+            for p in &client.blocklist {
+                out.push_str(&format!("  {p}\n"));
             }
         }
         return Ok(CommandResult::output(out.trim_end().to_string()));

--- a/src/commands/emulation.rs
+++ b/src/commands/emulation.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use serde_json::json;
 
-use crate::cdp::CdpClient;
+use crate::cdp::{CdpClient, GeolocationOverride, ViewportOverride};
 use crate::result::CommandResult;
 
 /// Combined emulation parameters for the `emulate` command.
@@ -114,6 +114,7 @@ pub async fn emulate(
                 json!({}),
             )
             .await?;
+        client.viewport = None;
         actions.push("Viewport cleared".to_string());
     }
 
@@ -121,6 +122,7 @@ pub async fn emulate(
         client
             .send_to_target(session_id, "Emulation.clearGeolocationOverride", json!({}))
             .await?;
+        client.geolocation = None;
         actions.push("Geolocation cleared".to_string());
     }
 
@@ -159,6 +161,12 @@ pub async fn emulate(
                 }),
             )
             .await?;
+        client.viewport = Some(ViewportOverride {
+            width: w,
+            height: h,
+            device_scale_factor: dsf,
+            mobile: params.mobile,
+        });
         actions.push(format!(
             "Viewport set to {}x{} (scale: {}, mobile: {})",
             w, h, dsf, params.mobile
@@ -195,6 +203,11 @@ pub async fn emulate(
                 json!({ "latitude": lat, "longitude": lon, "accuracy": acc }),
             )
             .await?;
+        client.geolocation = Some(GeolocationOverride {
+            latitude: lat,
+            longitude: lon,
+            accuracy: acc,
+        });
         actions.push(format!(
             "Geolocation set to {}, {} (acc: {}m)",
             lat, lon, acc
@@ -204,13 +217,26 @@ pub async fn emulate(
     // 4. If no specific action taken, show current overrides
     if actions.is_empty() {
         let mut out = String::new();
-        if client.blocklist.is_empty() {
-            out.push_str("No emulation overrides active.\n");
-        } else {
+        if let Some(vp) = &client.viewport {
+            out.push_str(&format!(
+                "Viewport: {}x{} (scale: {}, mobile: {})\n",
+                vp.width, vp.height, vp.device_scale_factor, vp.mobile
+            ));
+        }
+        if let Some(geo) = &client.geolocation {
+            out.push_str(&format!(
+                "Geolocation: {}, {} (acc: {}m)\n",
+                geo.latitude, geo.longitude, geo.accuracy
+            ));
+        }
+        if !client.blocklist.is_empty() {
             out.push_str("Blocked URLs:\n");
             for p in &client.blocklist {
                 out.push_str(&format!("  {p}\n"));
             }
+        }
+        if out.is_empty() {
+            out.push_str("No emulation overrides active.");
         }
         return Ok(CommandResult::output(out.trim_end().to_string()));
     }

--- a/src/commands/evaluate.rs
+++ b/src/commands/evaluate.rs
@@ -51,8 +51,8 @@ pub async fn evaluate(
     let value = &result["result"];
     let val_type = value["type"].as_str().unwrap_or("undefined");
 
-    let mut output_hint = if format.is_text() {
-        match val_type {
+    let output_hint = if format.is_text() {
+        let mut text = match val_type {
             "undefined" => "undefined".to_string(),
             "string" => value["value"].as_str().unwrap_or("").to_string(),
             _ => {
@@ -62,19 +62,20 @@ pub async fn evaluate(
                     value["description"].as_str().unwrap_or("").to_string()
                 }
             }
+        };
+
+        if expression.contains("querySelector")
+            || expression.contains("document.body")
+            || expression.contains("getElementById")
+            || expression.contains("getElementsBy")
+        {
+            text.push_str("\n\n[HINT: Avoid using `evaluate` for DOM traversal. Use the `snapshot` command to get a clean accessibility tree of the page, then use `click` or `fill`.]");
         }
+        text
     } else {
         let v = value.get("value").unwrap_or(value);
         format_structured(v, format)?
     };
-
-    if expression.contains("querySelector")
-        || expression.contains("document.body")
-        || expression.contains("getElementById")
-        || expression.contains("getElementsBy")
-    {
-        output_hint.push_str("\n\n[HINT: Avoid using `evaluate` for DOM traversal. Use the `snapshot` command to get a clean accessibility tree of the page, then use `click` or `fill`.]");
-    }
 
     if let Some(initial_url) = initial_url {
         let new_url = client.current_url(session_id).await?;

--- a/src/commands/evaluate.rs
+++ b/src/commands/evaluate.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use serde_json::json;
 
 use crate::cdp::CdpClient;
+use crate::format::{format_structured, OutputFormat};
 use crate::result::CommandResult;
 
 /// Evaluate a JavaScript expression in the page and return the result.
@@ -9,7 +10,7 @@ pub async fn evaluate(
     client: &mut CdpClient,
     session_id: &str,
     expression: &str,
-    as_json: bool,
+    format: OutputFormat,
     output: Option<&str>,
     track_navigation: bool,
 ) -> Result<CommandResult> {
@@ -50,13 +51,7 @@ pub async fn evaluate(
     let value = &result["result"];
     let val_type = value["type"].as_str().unwrap_or("undefined");
 
-    let mut output_hint = if as_json {
-        if let Some(v) = value.get("value") {
-            serde_json::to_string_pretty(v)?
-        } else {
-            serde_json::to_string_pretty(value)?
-        }
-    } else {
+    let mut output_hint = if format.is_text() {
         match val_type {
             "undefined" => "undefined".to_string(),
             "string" => value["value"].as_str().unwrap_or("").to_string(),
@@ -68,6 +63,9 @@ pub async fn evaluate(
                 }
             }
         }
+    } else {
+        let v = value.get("value").unwrap_or(value);
+        format_structured(v, format)?
     };
 
     if expression.contains("querySelector")

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -142,8 +142,11 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                     clear_viewport: false,
                     clear_geolocation: false,
                     clear_all: false,
-                    block_url: Vec::new(),
-                    unblock_url: Vec::new(),
+                    // Apply the global --block-url/--unblock-url flags to the new
+                    // tab during its initial load, matching direct mode and the
+                    // viewport/geolocation flags handled above.
+                    block_url: req.block_url.clone(),
+                    unblock_url: req.unblock_url.clone(),
                     clear_blocks: false,
                 };
                 params.validate()?;

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -24,7 +24,7 @@ pub fn known_args(cmd: &str) -> &'static [&'static str] {
         "press-key" => &["key"],
         "hover" => &["selector"],
         "snapshot" => &["output"],
-        "emulate" => &["viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_viewport", "clear_geolocation", "clear_all", "block_url", "unblock_url", "clear_blocks"],
+        "emulate" => &["viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_viewport", "clear_geolocation", "clear_all", "clear_blocks"],
         "wait-for" => &["text", "timeout"],
         "list-3p-tools" => &[],
         "execute-3p-tool" => &["name", "params"],
@@ -170,11 +170,11 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
         let _ = client.ensure_persistent_session(&target_id).await;
     }
 
-    // Apply global --block-url/--unblock-url flags (from DaemonRequest top-level
-    // fields) to the daemon's persistent blocklist. These survive across
-    // commands and target switches. Skip for "emulate" — the emulate handler
-    // manages its own block_url/unblock_url (the same CLI flags parse as both
-    // global and subcommand, so merging here would double-add).
+    // Apply the global --block-url/--unblock-url flags (from DaemonRequest
+    // top-level fields) to the daemon's persistent blocklist. These survive
+    // across commands and target switches. Skip for "emulate": its handler
+    // applies the same fields itself, ordered with --clear-blocks (clear first,
+    // then add), so merging here would both double-add and break that ordering.
     if cmd != "emulate" && (!req.block_url.is_empty() || !req.unblock_url.is_empty()) {
         for p in &req.block_url {
             if !client.blocklist.contains(p) {
@@ -196,12 +196,27 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
         };
     }
 
-    let session_id = client.attach_to_target(&target_id).await?;
+    // Prefer the persistent session so navigation, emulation, and event
+    // collection all share one stable session per target. This is what makes
+    // blocklist/emulation state actually govern the commands that run here
+    // (e.g. `navigate` is subject to the blocklist; `emulate --clear-*` clears
+    // overrides set by a previous `emulate`, since both run on the same session).
+    // Fall back to a fresh per-command session only if the persistent session
+    // isn't available for this target (e.g. its setup failed).
+    let using_persistent = client.persistent_session.is_some()
+        && client.persistent_target_id.as_deref() == Some(target_id.as_str());
+    let session_id = if using_persistent {
+        client.persistent_session.clone().unwrap()
+    } else {
+        client.attach_to_target(&target_id).await?
+    };
 
     let result = inner_execute(client, &session_id, req).await;
 
-    // Always run cleanup regardless of success/failure
-    let _ = client.detach_from_target(&session_id).await;
+    // Clean up only sessions we created here — never detach the persistent one.
+    if !using_persistent {
+        let _ = client.detach_from_target(&session_id).await;
+    }
     client.dialog_action = None;
 
     // Append target ID so the caller can pin subsequent commands to this page
@@ -349,21 +364,10 @@ async fn inner_execute(
             .await
         }
         "emulate" => {
-            // For the emulate subcommand, clap parses --block-url/--unblock-url
-            // as both the global flag AND the subcommand flag (same name). The
-            // subcommand-specific args are the canonical source — use those
-            // directly without merging the global fields (which would duplicate).
-            let block_url: Vec<String> = args
-                .get("block_url")
-                .and_then(|v| v.as_array())
-                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-                .unwrap_or_default();
-            let unblock_url: Vec<String> = args
-                .get("unblock_url")
-                .and_then(|v| v.as_array())
-                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
-                .unwrap_or_default();
-
+            // block/unblock come from the global request fields (the single flag
+            // definition); the emulate handler applies them itself — in the right
+            // order relative to --clear-blocks — which is why the generic merge
+            // above skips "emulate".
             let params = commands::emulation::EmulateParams {
                 viewport: args.get("viewport").and_then(|v| v.as_str()).map(|s| s.to_string()),
                 device_scale_factor: args.get("device_scale_factor").and_then(|v| v.as_f64()),
@@ -373,8 +377,8 @@ async fn inner_execute(
                 clear_viewport: args.get("clear_viewport").and_then(|v| v.as_bool()).unwrap_or(false),
                 clear_geolocation: args.get("clear_geolocation").and_then(|v| v.as_bool()).unwrap_or(false),
                 clear_all: args.get("clear_all").and_then(|v| v.as_bool()).unwrap_or(false),
-                block_url,
-                unblock_url,
+                block_url: req.block_url.clone(),
+                unblock_url: req.unblock_url.clone(),
                 clear_blocks: args.get("clear_blocks").and_then(|v| v.as_bool()).unwrap_or(false),
             };
             params.validate()?;

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -249,7 +249,14 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
     let session_id = if using_persistent {
         client.persistent_session.clone().unwrap()
     } else {
-        client.attach_to_target(&target_id).await?
+        // Degraded path: the persistent session is unavailable, so this fresh
+        // session won't have the blocklist that ensure_persistent_session
+        // normally applies. Re-apply it so blocking still takes effect.
+        let sid = client.attach_to_target(&target_id).await?;
+        if !client.blocklist.is_empty() {
+            client.apply_network_rules_internal(&sid).await;
+        }
+        sid
     };
 
     let result = inner_execute(client, &session_id, req).await;

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -225,7 +225,7 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
         for p in &req.unblock_url {
             client.blocklist.retain(|b| b != p);
         }
-        client.apply_network_rules().await;
+        client.apply_network_rules().await?;
     }
 
     // Special case for commands that target a page but don't need a session
@@ -254,7 +254,7 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
         // normally applies. Re-apply it so blocking still takes effect.
         let sid = client.attach_to_target(&target_id).await?;
         if !client.blocklist.is_empty() {
-            client.apply_network_rules_internal(&sid).await;
+            client.apply_network_rules_internal(&sid).await?;
         }
         sid
     };

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -211,20 +211,28 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
         let _ = client.ensure_persistent_session(&target_id).await;
     }
 
-    // Apply the global --block-url/--unblock-url flags (from DaemonRequest
-    // top-level fields) to the daemon's persistent blocklist. These survive
-    // across commands and target switches. Skip for "emulate": its handler
-    // applies the same fields itself, ordered with --clear-blocks (clear first,
-    // then add), so merging here would both double-add and break that ordering.
-    if cmd != "emulate" && (!req.block_url.is_empty() || !req.unblock_url.is_empty()) {
+    // Merge the global --block-url/--unblock-url flags (from DaemonRequest
+    // top-level fields) into the blocklist and apply them. This MUST run after
+    // ensure_persistent_session: that call swaps `blocklist` to the resolved
+    // target's per-tab list, so merging here lands the flags on the intended
+    // tab. Merging earlier would mutate (and leak into) whichever tab was
+    // active before the switch, and the swap would then discard the change.
+    //
+    // Skip "emulate": its handler applies these fields itself, ordered with
+    // --clear-blocks (clear first, then add). Skip close/select: no session.
+    // Browser-level commands returned early above, so --block-url with them is
+    // intentionally a no-op (a per-tab rule has no target tab there).
+    if cmd != "emulate"
+        && cmd != "close-page"
+        && cmd != "select-page"
+        && (!req.block_url.is_empty() || !req.unblock_url.is_empty())
+    {
         for p in &req.block_url {
             if !client.blocklist.contains(p) {
                 client.blocklist.push(p.clone());
             }
         }
-        for p in &req.unblock_url {
-            client.blocklist.retain(|b| b != p);
-        }
+        client.blocklist.retain(|b| !req.unblock_url.contains(b));
         client.apply_network_rules().await?;
     }
 

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -24,7 +24,7 @@ pub fn known_args(cmd: &str) -> &'static [&'static str] {
         "press-key" => &["key"],
         "hover" => &["selector"],
         "snapshot" => &["output"],
-        "emulate" => &["viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_viewport", "clear_geolocation", "clear_all", "block_url", "allow_url", "clear_blocks", "clear_allows"],
+        "emulate" => &["viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_viewport", "clear_geolocation", "clear_all", "block_url", "unblock_url", "clear_blocks"],
         "wait-for" => &["text", "timeout"],
         "list-3p-tools" => &[],
         "execute-3p-tool" => &["name", "params"],
@@ -109,9 +109,8 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                     clear_geolocation: false,
                     clear_all: false,
                     block_url: Vec::new(),
-                    allow_url: Vec::new(),
+                    unblock_url: Vec::new(),
                     clear_blocks: false,
-                    clear_allows: false,
                 };
                 params.validate()?;
 
@@ -171,18 +170,18 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
         let _ = client.ensure_persistent_session(&target_id).await;
     }
 
-    // Apply global --block-url/--allow-url flags (from DaemonRequest top-level
+    // Apply global --block-url/--unblock-url flags (from DaemonRequest top-level
     // fields) to the daemon's persistent blocklist. These survive across
     // commands and target switches. Skip for "emulate" — the emulate handler
-    // manages its own block_url/allow_url (the same CLI flags parse as both
+    // manages its own block_url/unblock_url (the same CLI flags parse as both
     // global and subcommand, so merging here would double-add).
-    if cmd != "emulate" && (!req.block_url.is_empty() || !req.allow_url.is_empty()) {
+    if cmd != "emulate" && (!req.block_url.is_empty() || !req.unblock_url.is_empty()) {
         for p in &req.block_url {
             if !client.blocklist.contains(p) {
                 client.blocklist.push(p.clone());
             }
         }
-        for p in &req.allow_url {
+        for p in &req.unblock_url {
             client.blocklist.retain(|b| b != p);
         }
         client.apply_network_rules().await;
@@ -249,9 +248,8 @@ async fn inner_execute(
                 clear_geolocation: false,
                 clear_all,
                 block_url: Vec::new(),
-                allow_url: Vec::new(),
+                unblock_url: Vec::new(),
                 clear_blocks: false,
-                clear_allows: false,
             };
             params.validate()?;
 
@@ -351,7 +349,7 @@ async fn inner_execute(
             .await
         }
         "emulate" => {
-            // For the emulate subcommand, clap parses --block-url/--allow-url
+            // For the emulate subcommand, clap parses --block-url/--unblock-url
             // as both the global flag AND the subcommand flag (same name). The
             // subcommand-specific args are the canonical source — use those
             // directly without merging the global fields (which would duplicate).
@@ -360,8 +358,8 @@ async fn inner_execute(
                 .and_then(|v| v.as_array())
                 .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
                 .unwrap_or_default();
-            let allow_url: Vec<String> = args
-                .get("allow_url")
+            let unblock_url: Vec<String> = args
+                .get("unblock_url")
                 .and_then(|v| v.as_array())
                 .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
                 .unwrap_or_default();
@@ -376,9 +374,8 @@ async fn inner_execute(
                 clear_geolocation: args.get("clear_geolocation").and_then(|v| v.as_bool()).unwrap_or(false),
                 clear_all: args.get("clear_all").and_then(|v| v.as_bool()).unwrap_or(false),
                 block_url,
-                allow_url,
+                unblock_url,
                 clear_blocks: args.get("clear_blocks").and_then(|v| v.as_bool()).unwrap_or(false),
-                clear_allows: args.get("clear_allows").and_then(|v| v.as_bool()).unwrap_or(false),
             };
             params.validate()?;
             commands::emulation::emulate(client, session_id, params).await
@@ -413,7 +410,7 @@ async fn inner_execute(
             let duration = args
                 .get("duration")
                 .and_then(|v| v.as_u64())
-                .unwrap_or(3000);
+                .unwrap_or(0);
             let types: Vec<String> = args
                 .get("type")
                 .and_then(|v| v.as_array())
@@ -436,7 +433,7 @@ async fn inner_execute(
             let duration = args
                 .get("duration")
                 .and_then(|v| v.as_u64())
-                .unwrap_or(3000);
+                .unwrap_or(0);
             let types: Vec<String> = args
                 .get("type")
                 .and_then(|v| v.as_array())

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -24,10 +24,14 @@ pub fn known_args(cmd: &str) -> &'static [&'static str] {
         "press-key" => &["key"],
         "hover" => &["selector"],
         "snapshot" => &["output"],
-        "emulate" => &["viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_viewport", "clear_geolocation", "clear_all"],
+        "emulate" => &["viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_viewport", "clear_geolocation", "clear_all", "block_url", "allow_url", "clear_blocks", "clear_allows"],
         "wait-for" => &["text", "timeout"],
         "list-3p-tools" => &[],
         "execute-3p-tool" => &["name", "params"],
+        "console" => &["duration", "type"],
+        "network" => &["duration", "type"],
+        "sw-logs" => &["duration", "extension_id"],
+        "kill-daemon" => &[],
         _ => &[],
     }
 }
@@ -61,7 +65,7 @@ fn validate_args(cmd: &str, args: &serde_json::Value) -> Result<()> {
 fn is_browser_level(cmd: &str) -> bool {
     matches!(
         cmd,
-        "list-pages" | "new-page"
+        "list-pages" | "new-page" | "sw-logs" | "kill-daemon"
     )
 }
 
@@ -70,19 +74,22 @@ fn is_browser_level(cmd: &str) -> bool {
 /// Handles target resolution, session attachment, dialog configuration,
 /// and target ID enrichment on success.
 pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Result<CommandResult> {
-    // Clear stale events from previous commands to prevent memory leak
-    // in long-running daemon mode and avoid stale events interfering
-    // with new command execution.
-    client.clear_events();
+    let cmd = req.command.as_str();
+
+    // Event-collecting commands drain the buffer via read_events_for,
+    // so they can capture events that arrived between commands.
+    // All other commands clear stale events to prevent memory buildup.
+    if !matches!(cmd, "console" | "network" | "sw-logs") {
+        client.clear_events();
+    }
 
     let args = &req.args;
-    let cmd = req.command.as_str();
 
     validate_args(cmd, args)?;
 
     if is_browser_level(cmd) {
         return match cmd {
-            "list-pages" => commands::pages::list_pages(client, req.json_output).await,
+            "list-pages" => commands::pages::list_pages(client, req.format()).await,
             "new-page" => {
                 let url = args
                     .get("url")
@@ -101,6 +108,10 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                     clear_viewport: false,
                     clear_geolocation: false,
                     clear_all: false,
+                    block_url: Vec::new(),
+                    allow_url: Vec::new(),
+                    clear_blocks: false,
+                    clear_allows: false,
                 };
                 params.validate()?;
 
@@ -111,6 +122,17 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                 };
 
                 commands::pages::new_page(client, url, params, args.get("extra_headers").and_then(|v| v.as_str())).await
+            }
+            "sw-logs" => {
+                let duration = args
+                    .get("duration")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(3000);
+                let extension_id = args.get("extension_id").and_then(|v| v.as_str());
+                commands::sw_logs::collect_sw_logs(client, duration, extension_id, req.format()).await
+            }
+            "kill-daemon" => {
+                Ok(CommandResult::output("kill-daemon is handled directly by the CLI, not the daemon."))
             }
             _ => unreachable!(),
         };
@@ -142,6 +164,29 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
 
     let target = client.resolve_page(target_id_arg, page_idx_arg).await?;
     let target_id = target.target_id.clone();
+
+    // Maintain a persistent CDP session for continuous event collection
+    // (Network + Console) across commands. Skip for close/select which don't need it.
+    if cmd != "close-page" && cmd != "select-page" {
+        let _ = client.ensure_persistent_session(&target_id).await;
+    }
+
+    // Apply global --block-url/--allow-url flags (from DaemonRequest top-level
+    // fields) to the daemon's persistent blocklist. These survive across
+    // commands and target switches. Skip for "emulate" — the emulate handler
+    // manages its own block_url/allow_url (the same CLI flags parse as both
+    // global and subcommand, so merging here would double-add).
+    if cmd != "emulate" && (!req.block_url.is_empty() || !req.allow_url.is_empty()) {
+        for p in &req.block_url {
+            if !client.blocklist.contains(p) {
+                client.blocklist.push(p.clone());
+            }
+        }
+        for p in &req.allow_url {
+            client.blocklist.retain(|b| b != p);
+        }
+        client.apply_network_rules().await;
+    }
 
     // Special case for commands that target a page but don't need a session
     if cmd == "close-page" || cmd == "select-page" {
@@ -203,6 +248,10 @@ async fn inner_execute(
                 clear_viewport: false,
                 clear_geolocation: false,
                 clear_all,
+                block_url: Vec::new(),
+                allow_url: Vec::new(),
+                clear_blocks: false,
+                clear_allows: false,
             };
             params.validate()?;
 
@@ -244,7 +293,7 @@ async fn inner_execute(
                     client,
                     session_id,
                     expr,
-                    req.json_output,
+                    req.format(),
                     args.get("output").and_then(|v| v.as_str()),
                     args.get("track_navigation")
                         .and_then(|v| v.as_bool())
@@ -296,12 +345,27 @@ async fn inner_execute(
             commands::snapshot::take_snapshot(
                 client,
                 session_id,
-                req.json_output,
+                req.format(),
                 args.get("output").and_then(|v| v.as_str()),
             )
             .await
         }
         "emulate" => {
+            // For the emulate subcommand, clap parses --block-url/--allow-url
+            // as both the global flag AND the subcommand flag (same name). The
+            // subcommand-specific args are the canonical source — use those
+            // directly without merging the global fields (which would duplicate).
+            let block_url: Vec<String> = args
+                .get("block_url")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .unwrap_or_default();
+            let allow_url: Vec<String> = args
+                .get("allow_url")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                .unwrap_or_default();
+
             let params = commands::emulation::EmulateParams {
                 viewport: args.get("viewport").and_then(|v| v.as_str()).map(|s| s.to_string()),
                 device_scale_factor: args.get("device_scale_factor").and_then(|v| v.as_f64()),
@@ -311,6 +375,10 @@ async fn inner_execute(
                 clear_viewport: args.get("clear_viewport").and_then(|v| v.as_bool()).unwrap_or(false),
                 clear_geolocation: args.get("clear_geolocation").and_then(|v| v.as_bool()).unwrap_or(false),
                 clear_all: args.get("clear_all").and_then(|v| v.as_bool()).unwrap_or(false),
+                block_url,
+                allow_url,
+                clear_blocks: args.get("clear_blocks").and_then(|v| v.as_bool()).unwrap_or(false),
+                clear_allows: args.get("clear_allows").and_then(|v| v.as_bool()).unwrap_or(false),
             };
             params.validate()?;
             commands::emulation::emulate(client, session_id, params).await
@@ -326,7 +394,7 @@ async fn inner_execute(
             None => bail!("text required"),
         },
         "list-3p-tools" => {
-            commands::third_party::list_3p_tools(client, session_id, req.json_output).await
+            commands::third_party::list_3p_tools(client, session_id, req.format()).await
         }
         "execute-3p-tool" => match args.get("name").and_then(|v| v.as_str()) {
             Some(name) => {
@@ -335,12 +403,58 @@ async fn inner_execute(
                     session_id,
                     name,
                     args.get("params").and_then(|v| v.as_str()),
-                    req.json_output,
+                    req.format(),
                 )
                 .await
             }
             None => bail!("name required"),
         },
+        "console" => {
+            let duration = args
+                .get("duration")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(3000);
+            let types: Vec<String> = args
+                .get("type")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            commands::console::collect_console(
+                client,
+                session_id,
+                duration,
+                types,
+                req.format(),
+            )
+            .await
+        }
+        "network" => {
+            let duration = args
+                .get("duration")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(3000);
+            let types: Vec<String> = args
+                .get("type")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            commands::network::collect_network(
+                client,
+                session_id,
+                duration,
+                types,
+                req.format(),
+            )
+            .await
+        }
         _ => bail!("Unknown command: {cmd}"),
     }
 }

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -11,10 +11,31 @@ use crate::result::CommandResult;
 pub fn known_args(cmd: &str) -> &'static [&'static str] {
     match cmd {
         "list-pages" => &[],
-        "new-page" => &["url", "viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "extra_headers"],
+        "new-page" => &[
+            "url",
+            "viewport",
+            "device_scale_factor",
+            "mobile",
+            "geolocation",
+            "accuracy",
+            "extra_headers",
+        ],
         "close-page" => &["id_or_index"],
         "select-page" => &["id_or_index"],
-        "navigate" => &["url", "back", "forward", "reload", "extra_headers", "viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_all", "output"],
+        "navigate" => &[
+            "url",
+            "back",
+            "forward",
+            "reload",
+            "extra_headers",
+            "viewport",
+            "device_scale_factor",
+            "mobile",
+            "geolocation",
+            "accuracy",
+            "clear_all",
+            "output",
+        ],
         "screenshot" => &["output", "format", "full_page"],
         "evaluate" => &["expression", "dialog_action", "output", "track_navigation"],
         "click" => &["selector"],
@@ -24,7 +45,17 @@ pub fn known_args(cmd: &str) -> &'static [&'static str] {
         "press-key" => &["key"],
         "hover" => &["selector"],
         "snapshot" => &["output"],
-        "emulate" => &["viewport", "device_scale_factor", "mobile", "geolocation", "accuracy", "clear_viewport", "clear_geolocation", "clear_all", "clear_blocks"],
+        "emulate" => &[
+            "viewport",
+            "device_scale_factor",
+            "mobile",
+            "geolocation",
+            "accuracy",
+            "clear_viewport",
+            "clear_geolocation",
+            "clear_all",
+            "clear_blocks",
+        ],
         "wait-for" => &["text", "timeout"],
         "list-3p-tools" => &[],
         "execute-3p-tool" => &["name", "params"],
@@ -40,14 +71,17 @@ pub fn known_args(cmd: &str) -> &'static [&'static str] {
 fn validate_args(cmd: &str, args: &serde_json::Value) -> Result<()> {
     let known = known_args(cmd);
     if let Some(obj) = args.as_object() {
-        let unknown: Vec<&String> = obj.keys().filter(|k| {
-            let key = k.as_str();
-            // dialog_action is handled globally for all page-level commands
-            if key == "dialog_action" && !is_browser_level(cmd) {
-                return false;
-            }
-            !known.contains(&key)
-        }).collect();
+        let unknown: Vec<&String> = obj
+            .keys()
+            .filter(|k| {
+                let key = k.as_str();
+                // dialog_action is handled globally for all page-level commands
+                if key == "dialog_action" && !is_browser_level(cmd) {
+                    return false;
+                }
+                !known.contains(&key)
+            })
+            .collect();
         if !unknown.is_empty() {
             let unknown_names: Vec<&str> = unknown.iter().map(|s| s.as_str()).collect();
             bail!(
@@ -63,10 +97,7 @@ fn validate_args(cmd: &str, args: &serde_json::Value) -> Result<()> {
 
 /// Whether a command operates at the browser level (no page session needed).
 fn is_browser_level(cmd: &str) -> bool {
-    matches!(
-        cmd,
-        "list-pages" | "new-page" | "sw-logs" | "kill-daemon"
-    )
+    matches!(cmd, "list-pages" | "new-page" | "sw-logs" | "kill-daemon")
 }
 
 /// Execute a single command from a [`DaemonRequest`].
@@ -102,7 +133,10 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                 let params = commands::emulation::EmulateParams {
                     viewport: viewport.map(|s| s.to_string()),
                     device_scale_factor: args.get("device_scale_factor").and_then(|v| v.as_f64()),
-                    mobile: args.get("mobile").and_then(|v| v.as_bool()).unwrap_or(false),
+                    mobile: args
+                        .get("mobile")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
                     geolocation: geolocation.map(|s| s.to_string()),
                     accuracy: args.get("accuracy").and_then(|v| v.as_f64()),
                     clear_viewport: false,
@@ -120,7 +154,13 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                     None
                 };
 
-                commands::pages::new_page(client, url, params, args.get("extra_headers").and_then(|v| v.as_str())).await
+                commands::pages::new_page(
+                    client,
+                    url,
+                    params,
+                    args.get("extra_headers").and_then(|v| v.as_str()),
+                )
+                .await
             }
             "sw-logs" => {
                 let duration = args
@@ -128,11 +168,12 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                     .and_then(|v| v.as_u64())
                     .unwrap_or(3000);
                 let extension_id = args.get("extension_id").and_then(|v| v.as_str());
-                commands::sw_logs::collect_sw_logs(client, duration, extension_id, req.format()).await
+                commands::sw_logs::collect_sw_logs(client, duration, extension_id, req.format())
+                    .await
             }
-            "kill-daemon" => {
-                Ok(CommandResult::output("kill-daemon is handled directly by the CLI, not the daemon."))
-            }
+            "kill-daemon" => Ok(CommandResult::output(
+                "kill-daemon is handled directly by the CLI, not the daemon.",
+            )),
             _ => unreachable!(),
         };
     }
@@ -149,10 +190,10 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
                 }
             }
             Some(v) if v.is_number() => {
-                let idx = v.as_u64()
-                    .ok_or_else(|| anyhow!("invalid numeric id_or_index: must be a non-negative integer"))?;
-                let idx_usize = usize::try_from(idx)
-                    .map_err(|_| anyhow!("index too large"))?;
+                let idx = v.as_u64().ok_or_else(|| {
+                    anyhow!("invalid numeric id_or_index: must be a non-negative integer")
+                })?;
+                let idx_usize = usize::try_from(idx).map_err(|_| anyhow!("index too large"))?;
                 (None, Some(idx_usize))
             }
             _ => (req.target.as_deref(), req.page),
@@ -251,12 +292,18 @@ async fn inner_execute(
             // Apply emulation before navigation if requested
             let viewport = args.get("viewport").and_then(|v| v.as_str());
             let geolocation = args.get("geolocation").and_then(|v| v.as_str());
-            let clear_all = args.get("clear_all").and_then(|v| v.as_bool()).unwrap_or(false);
+            let clear_all = args
+                .get("clear_all")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
 
             let params = commands::emulation::EmulateParams {
                 viewport: viewport.map(|s| s.to_string()),
                 device_scale_factor: args.get("device_scale_factor").and_then(|v| v.as_f64()),
-                mobile: args.get("mobile").and_then(|v| v.as_bool()).unwrap_or(false),
+                mobile: args
+                    .get("mobile")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
                 geolocation: geolocation.map(|s| s.to_string()),
                 accuracy: args.get("accuracy").and_then(|v| v.as_f64()),
                 clear_viewport: false,
@@ -369,17 +416,38 @@ async fn inner_execute(
             // order relative to --clear-blocks — which is why the generic merge
             // above skips "emulate".
             let params = commands::emulation::EmulateParams {
-                viewport: args.get("viewport").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                viewport: args
+                    .get("viewport")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
                 device_scale_factor: args.get("device_scale_factor").and_then(|v| v.as_f64()),
-                mobile: args.get("mobile").and_then(|v| v.as_bool()).unwrap_or(false),
-                geolocation: args.get("geolocation").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                mobile: args
+                    .get("mobile")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                geolocation: args
+                    .get("geolocation")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
                 accuracy: args.get("accuracy").and_then(|v| v.as_f64()),
-                clear_viewport: args.get("clear_viewport").and_then(|v| v.as_bool()).unwrap_or(false),
-                clear_geolocation: args.get("clear_geolocation").and_then(|v| v.as_bool()).unwrap_or(false),
-                clear_all: args.get("clear_all").and_then(|v| v.as_bool()).unwrap_or(false),
+                clear_viewport: args
+                    .get("clear_viewport")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                clear_geolocation: args
+                    .get("clear_geolocation")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+                clear_all: args
+                    .get("clear_all")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
                 block_url: req.block_url.clone(),
                 unblock_url: req.unblock_url.clone(),
-                clear_blocks: args.get("clear_blocks").and_then(|v| v.as_bool()).unwrap_or(false),
+                clear_blocks: args
+                    .get("clear_blocks")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
             };
             params.validate()?;
             commands::emulation::emulate(client, session_id, params).await
@@ -411,10 +479,7 @@ async fn inner_execute(
             None => bail!("name required"),
         },
         "console" => {
-            let duration = args
-                .get("duration")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0);
+            let duration = args.get("duration").and_then(|v| v.as_u64()).unwrap_or(0);
             let types: Vec<String> = args
                 .get("type")
                 .and_then(|v| v.as_array())
@@ -424,20 +489,11 @@ async fn inner_execute(
                         .collect()
                 })
                 .unwrap_or_default();
-            commands::console::collect_console(
-                client,
-                session_id,
-                duration,
-                types,
-                req.format(),
-            )
-            .await
+            commands::console::collect_console(client, session_id, duration, types, req.format())
+                .await
         }
         "network" => {
-            let duration = args
-                .get("duration")
-                .and_then(|v| v.as_u64())
-                .unwrap_or(0);
+            let duration = args.get("duration").and_then(|v| v.as_u64()).unwrap_or(0);
             let types: Vec<String> = args
                 .get("type")
                 .and_then(|v| v.as_array())
@@ -447,14 +503,8 @@ async fn inner_execute(
                         .collect()
                 })
                 .unwrap_or_default();
-            commands::network::collect_network(
-                client,
-                session_id,
-                duration,
-                types,
-                req.format(),
-            )
-            .await
+            commands::network::collect_network(client, session_id, duration, types, req.format())
+                .await
         }
         _ => bail!("Unknown command: {cmd}"),
     }

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -261,12 +261,14 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
         client.persistent_session.clone().unwrap()
     } else {
         // Degraded path: the persistent session is unavailable, so this fresh
-        // session won't have the blocklist that ensure_persistent_session
-        // normally applies. Re-apply it so blocking still takes effect.
+        // session won't have the blocklist or emulation that
+        // ensure_persistent_session normally applies. Re-apply them so
+        // overrides still take effect.
         let sid = client.attach_to_target(&target_id).await?;
         if !client.blocklist.is_empty() {
             client.apply_network_rules_internal(&sid).await?;
         }
+        client.apply_emulation_internal(&sid).await?;
         sid
     };
 

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -226,6 +226,7 @@ pub async fn execute_command(client: &mut CdpClient, req: &DaemonRequest) -> Res
     // Browser-level commands returned early above, so --block-url with them is
     // intentionally a no-op (a per-tab rule has no target tab there).
     if cmd != "emulate"
+        && cmd != "navigate"
         && cmd != "close-page"
         && cmd != "select-page"
         && (!req.block_url.is_empty() || !req.unblock_url.is_empty())
@@ -329,8 +330,8 @@ async fn inner_execute(
                 clear_viewport: false,
                 clear_geolocation: false,
                 clear_all,
-                block_url: Vec::new(),
-                unblock_url: Vec::new(),
+                block_url: req.block_url.clone(),
+                unblock_url: req.unblock_url.clone(),
                 clear_blocks: false,
             };
             params.validate()?;

--- a/src/commands/input.rs
+++ b/src/commands/input.rs
@@ -153,7 +153,11 @@ async fn wait_for_navigation(client: &mut CdpClient, session_id: &str) -> Result
         .and_then(|t| t.get("frame"))
         .and_then(|f| f.get("id"))
         .and_then(|i| i.as_str())
-        .ok_or_else(|| anyhow!("Failed to determine main frame ID from Page.getFrameTree response: {frame_tree}"))?
+        .ok_or_else(|| {
+            anyhow!(
+                "Failed to determine main frame ID from Page.getFrameTree response: {frame_tree}"
+            )
+        })?
         .to_string();
 
     let nav_events = ["Page.frameStartedLoading", "Page.navigatedWithinDocument"];
@@ -312,20 +316,20 @@ if (tagName === 'input' && (type === 'checkbox' || type === 'radio')) {{
 
     let res_val = result["result"]["value"].as_str().unwrap_or("error");
 
-if res_val == "not_found" {
-         bail!("Element not found: {selector}");
-     } else if res_val == "option_not_found" {
-         bail!("Could not find option with text or value '{value}' in select element: {selector}");
-     } else if res_val == "file_input" {
-         bail!("Cannot fill file input with text: {selector}");
-     } else if res_val == "select_ok" || res_val == "checkbox_ok" || res_val == "textarea_ok" {
-         // For select/checkbox/textarea, the work is done entirely in JS
-         let new_url = client.current_url(session_id).await?;
-         return Ok(
-             CommandResult::output(format!("Filled '{selector}' with: {value}"))
-                 .with_navigated_to_if_changed(new_url, initial_url),
-         );
-     }
+    if res_val == "not_found" {
+        bail!("Element not found: {selector}");
+    } else if res_val == "option_not_found" {
+        bail!("Could not find option with text or value '{value}' in select element: {selector}");
+    } else if res_val == "file_input" {
+        bail!("Cannot fill file input with text: {selector}");
+    } else if res_val == "select_ok" || res_val == "checkbox_ok" || res_val == "textarea_ok" {
+        // For select/checkbox/textarea, the work is done entirely in JS
+        let new_url = client.current_url(session_id).await?;
+        return Ok(
+            CommandResult::output(format!("Filled '{selector}' with: {value}"))
+                .with_navigated_to_if_changed(new_url, initial_url),
+        );
+    }
 
     client
         .send_to_target(session_id, "Input.insertText", json!({"text": value}))

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,9 +1,12 @@
+pub mod console;
 pub mod emulation;
 pub mod evaluate;
 pub mod executor;
 pub mod input;
 pub mod navigate;
+pub mod network;
 pub mod pages;
 pub mod screenshot;
 pub mod snapshot;
+pub mod sw_logs;
 pub mod third_party;

--- a/src/commands/navigate.rs
+++ b/src/commands/navigate.rs
@@ -17,7 +17,10 @@ pub async fn navigate(
     output: Option<&str>,
 ) -> Result<CommandResult> {
     // Validate navigation intent before mutating session state
-    let intent_count = [back, forward, reload, url.is_some()].iter().filter(|&&b| b).count();
+    let intent_count = [back, forward, reload, url.is_some()]
+        .iter()
+        .filter(|&&b| b)
+        .count();
     if intent_count == 0 {
         bail!("URL required (or use --back, --forward, --reload)");
     }
@@ -152,7 +155,11 @@ async fn do_reload(
 }
 
 /// Poll until document.readyState is "complete" or the timeout expires.
-pub async fn wait_for_load(client: &mut CdpClient, session_id: &str, timeout_ms: u64) -> Result<()> {
+pub async fn wait_for_load(
+    client: &mut CdpClient,
+    session_id: &str,
+    timeout_ms: u64,
+) -> Result<()> {
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -187,7 +194,9 @@ pub async fn wait_for_load(client: &mut CdpClient, session_id: &str, timeout_ms:
                     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                     continue;
                 }
-                return Err(anyhow!("wait_for_load failed for session {session_id}: {e}"));
+                return Err(anyhow!(
+                    "wait_for_load failed for session {session_id}: {e}"
+                ));
             }
         }
 

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -23,13 +23,13 @@ pub async fn collect_network(
                 .send_to_target(session_id, "Network.enable", json!({}))
                 .await?;
         }
-        let events = client.read_events_for(duration_ms).await?;
+        let events_result = client.read_events_for(duration_ms).await;
         if client.persistent_session.is_none() {
             let _ = client
                 .send_to_target(session_id, "Network.disable", json!({}))
                 .await;
         }
-        events
+        events_result?
     } else {
         // Drain mode: return accumulated events from persistent session
         client.drain_network_events()
@@ -145,5 +145,138 @@ fn format_network_output(
     } else {
         let value = serde_json::to_value(requests)?;
         Ok(CommandResult::output(format_structured(&value, format)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_process_network_events_merges_request_and_response() {
+        let events = vec![
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-1",
+                    "request": {"url": "https://example.com/api", "method": "POST"},
+                    "type": "Fetch"
+                }
+            }),
+            json!({
+                "method": "Network.responseReceived",
+                "params": {
+                    "requestId": "req-1",
+                    "response": {"status": 201, "statusText": "Created"}
+                }
+            }),
+        ];
+        let out = process_network_events(&events, &[]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["url"], "https://example.com/api");
+        assert_eq!(out[0]["method"], "POST");
+        assert_eq!(out[0]["resourceType"], "Fetch");
+        assert_eq!(out[0]["status"], 201);
+        assert_eq!(out[0]["statusText"], "Created");
+    }
+
+    #[test]
+    fn test_process_network_events_loading_failed() {
+        let events = vec![
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-2",
+                    "request": {"url": "https://blocked.com/ads.js", "method": "GET"},
+                    "type": "Script"
+                }
+            }),
+            json!({
+                "method": "Network.loadingFailed",
+                "params": {
+                    "requestId": "req-2",
+                    "errorText": "net::ERR_BLOCKED_BY_CLIENT"
+                }
+            }),
+        ];
+        let out = process_network_events(&events, &[]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["status"], "failed");
+        assert_eq!(out[0]["error"], "net::ERR_BLOCKED_BY_CLIENT");
+    }
+
+    #[test]
+    fn test_process_network_events_type_filter() {
+        let events = vec![
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-a",
+                    "request": {"url": "https://example.com/page", "method": "GET"},
+                    "type": "Document"
+                }
+            }),
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-b",
+                    "request": {"url": "https://example.com/script.js", "method": "GET"},
+                    "type": "Script"
+                }
+            }),
+        ];
+        let filter = vec!["Document".to_string()];
+        let out = process_network_events(&events, &filter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["url"], "https://example.com/page");
+    }
+
+    #[test]
+    fn test_process_network_events_sorts_by_url() {
+        let events = vec![
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "r1",
+                    "request": {"url": "https://z.example.com/", "method": "GET"},
+                    "type": "Document"
+                }
+            }),
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "r2",
+                    "request": {"url": "https://a.example.com/", "method": "GET"},
+                    "type": "Document"
+                }
+            }),
+        ];
+        let out = process_network_events(&events, &[]);
+        assert_eq!(out[0]["url"], "https://a.example.com/");
+        assert_eq!(out[1]["url"], "https://z.example.com/");
+    }
+
+    #[test]
+    fn test_process_network_events_ignores_unknown_methods() {
+        let events = vec![
+            json!({"method": "Network.dataReceived", "params": {"requestId": "r1", "dataLength": 100}}),
+        ];
+        let out = process_network_events(&events, &[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_process_network_events_handles_response_without_request() {
+        // responseReceived arrives with no prior requestWillBeSent — should be dropped
+        let events = vec![json!({
+            "method": "Network.responseReceived",
+            "params": {
+                "requestId": "orphan",
+                "response": {"status": 200, "statusText": "OK"}
+            }
+        })];
+        let out = process_network_events(&events, &[]);
+        assert!(out.is_empty());
     }
 }

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -46,10 +46,14 @@ fn process_network_events(
     events: &[serde_json::Value],
     type_filter: &[String],
 ) -> Vec<serde_json::Value> {
-    let filter_set: Option<std::collections::HashSet<&str>> = if type_filter.is_empty() {
+    // Match case-insensitively: CDP emits capitalized resource types
+    // (e.g. "Fetch", "XHR"), but the CLI help documents lowercase
+    // (e.g. "fetch", "xhr"). Normalize both sides to lowercase so the
+    // documented input actually matches.
+    let filter_set: Option<std::collections::HashSet<String>> = if type_filter.is_empty() {
         None
     } else {
-        Some(type_filter.iter().map(|s| s.as_str()).collect())
+        Some(type_filter.iter().map(|s| s.to_lowercase()).collect())
     };
 
     let mut requests: HashMap<String, serde_json::Value> = HashMap::new();
@@ -117,7 +121,7 @@ fn process_network_events(
         filtered.retain(|r| {
             r["resourceType"]
                 .as_str()
-                .map(|t| set.contains(t))
+                .map(|t| set.contains(&t.to_lowercase()))
                 .unwrap_or(false)
         });
     }
@@ -237,6 +241,37 @@ mod tests {
         let out = process_network_events(&events, &filter);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0]["url"], "https://example.com/page");
+    }
+
+    #[test]
+    fn test_process_network_events_type_filter_case_insensitive() {
+        // The CLI help documents lowercase resource types, but CDP emits them
+        // capitalized. Documented lowercase input must still match, and the
+        // output must preserve the original CDP casing.
+        let events = vec![
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-a",
+                    "request": {"url": "https://example.com/api", "method": "GET"},
+                    "type": "Fetch"
+                }
+            }),
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-b",
+                    "request": {"url": "https://example.com/x", "method": "GET"},
+                    "type": "XHR"
+                }
+            }),
+        ];
+        // lowercase "fetch" (as documented) and odd-cased "xhr"/"Xhr".
+        let filter = vec!["fetch".to_string(), "Xhr".to_string()];
+        let out = process_network_events(&events, &filter);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0]["resourceType"], "Fetch");
+        assert_eq!(out[1]["resourceType"], "XHR");
     }
 
     #[test]

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -53,6 +53,9 @@ fn process_network_events(
     };
 
     let mut requests: HashMap<String, serde_json::Value> = HashMap::new();
+    // First-seen order of request IDs, so output follows the network timeline
+    // rather than an arbitrary HashMap / alphabetical ordering.
+    let mut order: Vec<String> = Vec::new();
 
     for event in events {
         let method = event["method"].as_str().unwrap_or("");
@@ -68,6 +71,11 @@ fn process_network_events(
                     .unwrap_or("GET")
                     .to_string();
 
+                // Record first-seen position; redirects reuse the same requestId
+                // and update the record in place without changing its position.
+                if !requests.contains_key(&request_id) {
+                    order.push(request_id.clone());
+                }
                 requests.insert(
                     request_id,
                     json!({
@@ -100,7 +108,11 @@ fn process_network_events(
         }
     }
 
-    let mut filtered: Vec<serde_json::Value> = requests.into_values().collect();
+    // Emit in first-seen (chronological) order rather than HashMap order.
+    let mut filtered: Vec<serde_json::Value> = order
+        .into_iter()
+        .filter_map(|id| requests.remove(&id))
+        .collect();
     if let Some(ref set) = filter_set {
         filtered.retain(|r| {
             r["resourceType"]
@@ -109,14 +121,6 @@ fn process_network_events(
                 .unwrap_or(false)
         });
     }
-
-    // Sort by URL for stable output
-    filtered.sort_by(|a, b| {
-        a["url"]
-            .as_str()
-            .unwrap_or("")
-            .cmp(b["url"].as_str().unwrap_or(""))
-    });
 
     filtered
 }
@@ -236,7 +240,8 @@ mod tests {
     }
 
     #[test]
-    fn test_process_network_events_sorts_by_url() {
+    fn test_process_network_events_preserves_chronological_order() {
+        // Output should follow first-seen (request order), NOT alphabetical URL.
         let events = vec![
             json!({
                 "method": "Network.requestWillBeSent",
@@ -256,8 +261,8 @@ mod tests {
             }),
         ];
         let out = process_network_events(&events, &[]);
-        assert_eq!(out[0]["url"], "https://a.example.com/");
-        assert_eq!(out[1]["url"], "https://z.example.com/");
+        assert_eq!(out[0]["url"], "https://z.example.com/");
+        assert_eq!(out[1]["url"], "https://a.example.com/");
     }
 
     #[test]

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -75,9 +75,33 @@ fn process_network_events(
                     .unwrap_or("GET")
                     .to_string();
 
-                // Record first-seen position; redirects reuse the same requestId
-                // and update the record in place without changing its position.
-                if !requests.contains_key(&request_id) {
+                // A redirect re-fires requestWillBeSent with the same requestId,
+                // and Chrome sends NO separate responseReceived for the hop — its
+                // 3xx status lives only on `redirectResponse`. Stash the prior hop
+                // (with that status) as its own entry so redirect chains stay
+                // visible instead of being overwritten by the final request.
+                if requests.contains_key(&request_id) {
+                    if let Some(redirect) = params.get("redirectResponse") {
+                        if let Some(mut prev) = requests.get(&request_id).cloned() {
+                            prev["status"] = json!(redirect["status"].as_u64().unwrap_or(0));
+                            prev["statusText"] =
+                                json!(redirect["statusText"].as_str().unwrap_or(""));
+
+                            let mut counter = 1;
+                            let mut redirect_id = format!("{request_id}#redirect{counter}");
+                            while requests.contains_key(&redirect_id) {
+                                counter += 1;
+                                redirect_id = format!("{request_id}#redirect{counter}");
+                            }
+                            // Insert the hop just before the final request so the
+                            // timeline reads request -> redirect(s) -> final.
+                            if let Some(pos) = order.iter().position(|id| id == &request_id) {
+                                order.insert(pos, redirect_id.clone());
+                            }
+                            requests.insert(redirect_id, prev);
+                        }
+                    }
+                } else {
                     order.push(request_id.clone());
                 }
                 requests.insert(
@@ -307,6 +331,51 @@ mod tests {
         ];
         let out = process_network_events(&events, &[]);
         assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_process_network_events_preserves_redirect_chain() {
+        // A redirect re-fires requestWillBeSent with the same requestId and a
+        // redirectResponse carrying the 3xx status of the previous hop. The hop
+        // must survive as its own entry (with its 301), not be overwritten.
+        let events = vec![
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-r",
+                    "request": {"url": "https://example.com/old", "method": "GET"},
+                    "type": "Document"
+                }
+            }),
+            json!({
+                "method": "Network.requestWillBeSent",
+                "params": {
+                    "requestId": "req-r",
+                    "request": {"url": "https://example.com/new", "method": "GET"},
+                    "type": "Document",
+                    "redirectResponse": {"status": 301, "statusText": "Moved Permanently"}
+                }
+            }),
+            json!({
+                "method": "Network.responseReceived",
+                "params": {
+                    "requestId": "req-r",
+                    "response": {"status": 200, "statusText": "OK"}
+                }
+            }),
+        ];
+        let out = process_network_events(&events, &[]);
+        assert_eq!(out.len(), 2);
+        // Redirect hop first (chronological), with its real 301 status.
+        assert_eq!(out[0]["url"], "https://example.com/old");
+        assert_eq!(out[0]["status"], 301);
+        assert_eq!(out[0]["statusText"], "Moved Permanently");
+        // Final request second, with its resolved 200.
+        assert_eq!(out[1]["url"], "https://example.com/new");
+        assert_eq!(out[1]["status"], 200);
+        // Synthetic redirect keys are internal — they must not leak into output.
+        assert!(out[0].get("requestId").is_none());
+        assert!(out[1].get("requestId").is_none());
     }
 
     #[test]

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -14,25 +14,28 @@ pub async fn collect_network(
     type_filter: Vec<String>,
     format: OutputFormat,
 ) -> Result<CommandResult> {
-    let events = if duration_ms > 0 {
-        // Live mode: the persistent session already has Network enabled,
-        // so we skip enabling it on the command's own session to avoid
-        // duplicate events from two sessions both receiving the same messages.
-        if client.persistent_session.is_none() {
-            client
-                .send_to_target(session_id, "Network.enable", json!({}))
-                .await?;
-        }
-        let events_result = client.read_events_for(duration_ms).await;
-        if client.persistent_session.is_none() {
-            let _ = client
-                .send_to_target(session_id, "Network.disable", json!({}))
-                .await;
-        }
-        events_result?
-    } else {
-        // Drain mode: return accumulated events from persistent session
+    let events = if duration_ms == 0 {
+        // Drain mode: return accumulated events from the persistent session.
         client.drain_network_events()
+    } else if client.persistent_session.is_some() {
+        // Live mode, daemon: the persistent session already has Network enabled
+        // and push_event accumulates its events into network_events. Read for the
+        // window so they land in the buffer, then drain the buffer as the single
+        // source of truth. Draining also consumes them, so a later drain can't
+        // repeat them (read_events_for's own return value would double-count).
+        client.read_events_for(duration_ms).await?;
+        client.drain_network_events()
+    } else {
+        // Live mode, direct/fallback: no persistent buffer. Enable Network on our
+        // own session, collect for the window, disable, and return what we read.
+        client
+            .send_to_target(session_id, "Network.enable", json!({}))
+            .await?;
+        let events_result = client.read_events_for(duration_ms).await;
+        let _ = client
+            .send_to_target(session_id, "Network.disable", json!({}))
+            .await;
+        events_result?
     };
 
     let requests = process_network_events(&events, &type_filter);

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -64,7 +64,10 @@ fn process_network_events(
     for event in events {
         let method = event["method"].as_str().unwrap_or("");
         let params = &event["params"];
-        let request_id = params["requestId"].as_str().unwrap_or("").to_string();
+        let request_id = match params["requestId"].as_str() {
+            Some(id) if !id.is_empty() => id.to_string(),
+            _ => continue,
+        };
 
         match method {
             "Network.requestWillBeSent" => {

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -1,0 +1,149 @@
+use anyhow::Result;
+use serde_json::json;
+use std::collections::HashMap;
+use std::fmt::Write;
+
+use crate::cdp::CdpClient;
+use crate::format::{format_structured, OutputFormat};
+use crate::result::CommandResult;
+
+pub async fn collect_network(
+    client: &mut CdpClient,
+    session_id: &str,
+    duration_ms: u64,
+    type_filter: Vec<String>,
+    format: OutputFormat,
+) -> Result<CommandResult> {
+    let events = if duration_ms > 0 {
+        // Live mode: the persistent session already has Network enabled,
+        // so we skip enabling it on the command's own session to avoid
+        // duplicate events from two sessions both receiving the same messages.
+        if client.persistent_session.is_none() {
+            client
+                .send_to_target(session_id, "Network.enable", json!({}))
+                .await?;
+        }
+        let events = client.read_events_for(duration_ms).await?;
+        if client.persistent_session.is_none() {
+            let _ = client
+                .send_to_target(session_id, "Network.disable", json!({}))
+                .await;
+        }
+        events
+    } else {
+        // Drain mode: return accumulated events from persistent session
+        client.drain_network_events()
+    };
+
+    let requests = process_network_events(&events, &type_filter);
+    format_network_output(&requests, format)
+}
+
+fn process_network_events(
+    events: &[serde_json::Value],
+    type_filter: &[String],
+) -> Vec<serde_json::Value> {
+    let filter_set: Option<std::collections::HashSet<&str>> = if type_filter.is_empty() {
+        None
+    } else {
+        Some(type_filter.iter().map(|s| s.as_str()).collect())
+    };
+
+    let mut requests: HashMap<String, serde_json::Value> = HashMap::new();
+
+    for event in events {
+        let method = event["method"].as_str().unwrap_or("");
+        let params = &event["params"];
+        let request_id = params["requestId"].as_str().unwrap_or("").to_string();
+
+        match method {
+            "Network.requestWillBeSent" => {
+                let url = params["request"]["url"].as_str().unwrap_or("").to_string();
+                let resource_type = params["type"].as_str().unwrap_or("Other").to_string();
+                let http_method = params["request"]["method"]
+                    .as_str()
+                    .unwrap_or("GET")
+                    .to_string();
+
+                requests.insert(
+                    request_id,
+                    json!({
+                        "url": url,
+                        "method": http_method,
+                        "resourceType": resource_type,
+                        "status": null,
+                    }),
+                );
+            }
+            "Network.responseReceived" => {
+                if let Some(req) = requests.get_mut(&request_id) {
+                    let status = params["response"]["status"].as_u64().unwrap_or(0);
+                    let status_text = params["response"]["statusText"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_string();
+                    req["status"] = json!(status);
+                    req["statusText"] = json!(status_text);
+                }
+            }
+            "Network.loadingFailed" => {
+                if let Some(req) = requests.get_mut(&request_id) {
+                    let error = params["errorText"].as_str().unwrap_or("failed").to_string();
+                    req["status"] = json!("failed");
+                    req["error"] = json!(error);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut filtered: Vec<serde_json::Value> = requests.into_values().collect();
+    if let Some(ref set) = filter_set {
+        filtered.retain(|r| {
+            r["resourceType"]
+                .as_str()
+                .map(|t| set.contains(t))
+                .unwrap_or(false)
+        });
+    }
+
+    // Sort by URL for stable output
+    filtered.sort_by(|a, b| {
+        a["url"]
+            .as_str()
+            .unwrap_or("")
+            .cmp(b["url"].as_str().unwrap_or(""))
+    });
+
+    filtered
+}
+
+fn format_network_output(
+    requests: &[serde_json::Value],
+    format: OutputFormat,
+) -> Result<CommandResult> {
+    if format.is_text() {
+        if requests.is_empty() {
+            return Ok(CommandResult::output(
+                "No network requests collected.".to_string(),
+            ));
+        }
+        let mut out = String::new();
+        writeln!(out, "{:<8} {:<6} {}", "STATUS", "METHOD", "URL").unwrap();
+        writeln!(out, "{}", "-".repeat(72)).unwrap();
+        for req in requests {
+            let status = match &req["status"] {
+                serde_json::Value::Number(n) => n.to_string(),
+                serde_json::Value::String(s) => s.clone(),
+                _ => "?".to_string(),
+            };
+            let method = req["method"].as_str().unwrap_or("?");
+            let url = req["url"].as_str().unwrap_or("?");
+            writeln!(out, "{:<8} {:<6} {}", status, method, url).unwrap();
+        }
+        Ok(CommandResult::output(out))
+    } else {
+        let value = serde_json::to_value(requests)?;
+        Ok(CommandResult::output(format_structured(&value, format)?))
+    }
+}

--- a/src/commands/pages.rs
+++ b/src/commands/pages.rs
@@ -153,6 +153,8 @@ pub async fn new_page(
 /// Close a page target by its target ID.
 pub async fn close_page(client: &mut CdpClient, target_id: &str) -> Result<CommandResult> {
     client.close_target(target_id).await?;
+    // Drop the closed tab's saved emulation state so it doesn't linger.
+    client.forget_target(target_id);
     let friendly_name = friendly::to_friendly(target_id);
     Ok(CommandResult::output(format!(
         "Closed page: {friendly_name}"

--- a/src/commands/pages.rs
+++ b/src/commands/pages.rs
@@ -26,7 +26,10 @@ pub async fn apply_extra_headers(
                 serde_json::Value::String(s) => s.clone(),
                 serde_json::Value::Number(n) => n.to_string(),
                 serde_json::Value::Bool(b) => b.to_string(),
-                _ => anyhow::bail!("Header value for '{}' must be a primitive scalar (string, number, or boolean)", k),
+                _ => anyhow::bail!(
+                    "Header value for '{}' must be a primitive scalar (string, number, or boolean)",
+                    k
+                ),
             };
             converted_headers.insert(k.clone(), serde_json::Value::String(val_str));
         }
@@ -60,10 +63,7 @@ pub async fn clear_extra_headers(client: &mut CdpClient, session_id: &str) -> Re
 }
 
 /// List all open page targets with their friendly names, titles, and URLs.
-pub async fn list_pages(
-    client: &mut CdpClient,
-    format: OutputFormat,
-) -> Result<CommandResult> {
+pub async fn list_pages(client: &mut CdpClient, format: OutputFormat) -> Result<CommandResult> {
     let pages = client.get_page_targets().await?;
 
     if format.is_text() {
@@ -119,7 +119,12 @@ pub async fn new_page(
                 if let Some(error_text) = nav_result.get("errorText").and_then(|v| v.as_str()) {
                     anyhow::bail!("Page.navigate failed: {error_text}");
                 }
-                crate::commands::navigate::wait_for_load(client, &session_id, NAVIGATION_TIMEOUT_MS).await?;
+                crate::commands::navigate::wait_for_load(
+                    client,
+                    &session_id,
+                    NAVIGATION_TIMEOUT_MS,
+                )
+                .await?;
                 Ok(())
             }
             .await;
@@ -149,7 +154,9 @@ pub async fn new_page(
 pub async fn close_page(client: &mut CdpClient, target_id: &str) -> Result<CommandResult> {
     client.close_target(target_id).await?;
     let friendly_name = friendly::to_friendly(target_id);
-    Ok(CommandResult::output(format!("Closed page: {friendly_name}")))
+    Ok(CommandResult::output(format!(
+        "Closed page: {friendly_name}"
+    )))
 }
 
 /// Activate (bring to front) a page target by its target ID.
@@ -203,7 +210,9 @@ pub async fn wait_for(
                     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
                     continue;
                 }
-                return Err(anyhow::anyhow!("wait_for failed for session {session_id}: {e}"));
+                return Err(anyhow::anyhow!(
+                    "wait_for failed for session {session_id}: {e}"
+                ));
             }
         }
 

--- a/src/commands/pages.rs
+++ b/src/commands/pages.rs
@@ -4,6 +4,7 @@ use std::fmt::Write;
 
 use crate::cdp::CdpClient;
 use crate::constants::NAVIGATION_TIMEOUT_MS;
+use crate::format::{format_structured, OutputFormat};
 use crate::friendly;
 use crate::result::CommandResult;
 
@@ -59,10 +60,23 @@ pub async fn clear_extra_headers(client: &mut CdpClient, session_id: &str) -> Re
 }
 
 /// List all open page targets with their friendly names, titles, and URLs.
-pub async fn list_pages(client: &mut CdpClient, as_json: bool) -> Result<CommandResult> {
+pub async fn list_pages(
+    client: &mut CdpClient,
+    format: OutputFormat,
+) -> Result<CommandResult> {
     let pages = client.get_page_targets().await?;
 
-    if as_json {
+    if format.is_text() {
+        if pages.is_empty() {
+            return Ok(CommandResult::output("No pages open.".to_string()));
+        }
+        let mut out = String::new();
+        for (i, page) in pages.iter().enumerate() {
+            let name = friendly::to_friendly(&page.target_id);
+            writeln!(out, "[{i}] ({name}) {} — {}", page.title, page.url).unwrap();
+        }
+        Ok(CommandResult::output(out))
+    } else {
         let items: Vec<_> = pages
             .iter()
             .enumerate()
@@ -75,17 +89,8 @@ pub async fn list_pages(client: &mut CdpClient, as_json: bool) -> Result<Command
                 })
             })
             .collect();
-        Ok(CommandResult::output(serde_json::to_string_pretty(&items)?))
-    } else {
-        if pages.is_empty() {
-            return Ok(CommandResult::output("No pages open.".to_string()));
-        }
-        let mut out = String::new();
-        for (i, page) in pages.iter().enumerate() {
-            let name = friendly::to_friendly(&page.target_id);
-            writeln!(out, "[{i}] ({name}) {} — {}", page.title, page.url).unwrap();
-        }
-        Ok(CommandResult::output(out))
+        let value = serde_json::to_value(&items)?;
+        Ok(CommandResult::output(format_structured(&value, format)?))
     }
 }
 

--- a/src/commands/snapshot.rs
+++ b/src/commands/snapshot.rs
@@ -3,44 +3,47 @@ use serde_json::json;
 use std::fmt::Write;
 
 use crate::cdp::CdpClient;
+use crate::format::{format_structured, OutputFormat};
 use crate::result::CommandResult;
 
 /// Take an accessibility tree snapshot of the current page.
 pub async fn take_snapshot(
     client: &mut CdpClient,
     session_id: &str,
-    as_json: bool,
+    format: OutputFormat,
     output: Option<&str>,
 ) -> Result<CommandResult> {
     let result = client
         .send_to_target(session_id, "Accessibility.getFullAXTree", json!({}))
         .await?;
 
-    let content = if as_json {
-        serde_json::to_string_pretty(&result)?
-    } else if let Some(nodes) = result["nodes"].as_array() {
-        let mut out = String::new();
-        for node in nodes {
-            let role = node["role"]["value"].as_str().unwrap_or("");
-            let name = node["name"]["value"].as_str().unwrap_or("");
-            let node_id = node["nodeId"].as_str().unwrap_or("");
+    let content = if format.is_text() {
+        if let Some(nodes) = result["nodes"].as_array() {
+            let mut out = String::new();
+            for node in nodes {
+                let role = node["role"]["value"].as_str().unwrap_or("");
+                let name = node["name"]["value"].as_str().unwrap_or("");
+                let node_id = node["nodeId"].as_str().unwrap_or("");
 
-            if role == "none" || role == "generic" || role == "Ignored" {
-                continue;
+                if role == "none" || role == "generic" || role == "Ignored" {
+                    continue;
+                }
+
+                let depth = node["depth"].as_u64().unwrap_or(0) as usize;
+                let indent = "  ".repeat(depth);
+
+                if name.is_empty() {
+                    writeln!(out, "{indent}[{role}] #{node_id}").unwrap();
+                } else {
+                    writeln!(out, "{indent}[{role}] \"{name}\" #{node_id}").unwrap();
+                }
             }
-
-            let depth = node["depth"].as_u64().unwrap_or(0) as usize;
-            let indent = "  ".repeat(depth);
-
-            if name.is_empty() {
-                writeln!(out, "{indent}[{role}] #{node_id}").unwrap();
-            } else {
-                writeln!(out, "{indent}[{role}] \"{name}\" #{node_id}").unwrap();
-            }
+            out
+        } else {
+            serde_json::to_string_pretty(&result)?
         }
-        out
     } else {
-        serde_json::to_string_pretty(&result)?
+        format_structured(&result, format)?
     };
 
     Ok(CommandResult::output(content).save_output(output).await?)

--- a/src/commands/sw_logs.rs
+++ b/src/commands/sw_logs.rs
@@ -1,0 +1,150 @@
+use anyhow::Result;
+use serde_json::json;
+use std::fmt::Write;
+
+use crate::cdp::CdpClient;
+use crate::format::{format_structured, OutputFormat};
+use crate::result::CommandResult;
+
+const EXTENSION_PREFIX: &str = "chrome-extension://";
+
+pub async fn collect_sw_logs(
+    client: &mut CdpClient,
+    duration_ms: u64,
+    extension_id_filter: Option<&str>,
+    format: OutputFormat,
+) -> Result<CommandResult> {
+    let targets = client.get_all_targets().await?;
+
+    let sw_targets: Vec<_> = targets
+        .iter()
+        .filter(|t| {
+            t.target_type == "service_worker" && t.url.starts_with(EXTENSION_PREFIX)
+        })
+        .filter(|t| {
+            if let Some(filter_id) = extension_id_filter {
+                extract_extension_id(&t.url)
+                    .map(|id| id == filter_id)
+                    .unwrap_or(false)
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if sw_targets.is_empty() {
+        return Ok(CommandResult::output(
+            "No extension service workers found.".to_string(),
+        ));
+    }
+
+    let mut sessions = Vec::new();
+    for target in &sw_targets {
+        match client.attach_to_target(&target.target_id).await {
+            Ok(session_id) => {
+                let _ = client
+                    .send_to_target(&session_id, "Runtime.enable", json!({}))
+                    .await;
+                sessions.push(((*target).clone(), session_id));
+            }
+            Err(e) => {
+                eprintln!(
+                    "Warning: failed to attach to service worker {}: {e}",
+                    target.url
+                );
+            }
+        }
+    }
+
+    let events = client.read_events_for(duration_ms).await?;
+
+    for (_, session_id) in &sessions {
+        let _ = client
+            .send_to_target(session_id, "Runtime.disable", json!({}))
+            .await;
+        let _ = client.detach_from_target(session_id).await;
+    }
+
+    let mut messages = Vec::new();
+    for event in &events {
+        let method = event["method"].as_str().unwrap_or("");
+        let params = &event["params"];
+        let session_id = event["sessionId"].as_str().unwrap_or("");
+
+        let source = sessions
+            .iter()
+            .find(|(_, sid)| sid == session_id)
+            .map(|(t, _)| t.url.as_str())
+            .unwrap_or("unknown");
+
+        let ext_id = extract_extension_id(source).unwrap_or_default();
+
+        match method {
+            "Runtime.consoleAPICalled" => {
+                let msg_type = params["type"].as_str().unwrap_or("log");
+                let args: Vec<String> = params["args"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|arg| {
+                                arg["value"]
+                                    .as_str()
+                                    .or_else(|| arg["description"].as_str())
+                                    .unwrap_or("<object>")
+                                    .to_string()
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let text = args.join(" ");
+
+                messages.push(json!({
+                    "extensionId": ext_id,
+                    "type": msg_type,
+                    "text": text,
+                    "source": source,
+                }));
+            }
+            "Runtime.exceptionThrown" => {
+                let details = &params["exceptionDetails"];
+                let text = details["text"].as_str().unwrap_or("Unknown error");
+                let description = details["exception"]["description"]
+                    .as_str()
+                    .unwrap_or(text);
+
+                messages.push(json!({
+                    "extensionId": ext_id,
+                    "type": "exception",
+                    "text": description,
+                    "source": source,
+                }));
+            }
+            _ => {}
+        }
+    }
+
+    if format.is_text() {
+        if messages.is_empty() {
+            return Ok(CommandResult::output(
+                "No service worker logs collected.".to_string(),
+            ));
+        }
+        let mut out = String::new();
+        for msg in &messages {
+            let ext_id = msg["extensionId"].as_str().unwrap_or("?");
+            let msg_type = msg["type"].as_str().unwrap_or("?");
+            let text = msg["text"].as_str().unwrap_or("");
+            writeln!(out, "[{ext_id}] [{msg_type}] {text}").unwrap();
+        }
+        Ok(CommandResult::output(out))
+    } else {
+        let value = serde_json::to_value(&messages)?;
+        Ok(CommandResult::output(format_structured(&value, format)?))
+    }
+}
+
+fn extract_extension_id(url: &str) -> Option<String> {
+    let rest = url.strip_prefix(EXTENSION_PREFIX)?;
+    let slash = rest.find('/').unwrap_or(rest.len());
+    Some(rest[..slash].to_string())
+}

--- a/src/commands/sw_logs.rs
+++ b/src/commands/sw_logs.rs
@@ -40,10 +40,21 @@ pub async fn collect_sw_logs(
     for target in &sw_targets {
         match client.attach_to_target(&target.target_id).await {
             Ok(session_id) => {
-                let _ = client
+                match client
                     .send_to_target(&session_id, "Runtime.enable", json!({}))
-                    .await;
-                sessions.push(((*target).clone(), session_id));
+                    .await
+                {
+                    Ok(_) => {
+                        sessions.push(((*target).clone(), session_id));
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Warning: failed to enable Runtime for service worker {}: {e}",
+                            target.url
+                        );
+                        let _ = client.detach_from_target(&session_id).await;
+                    }
+                }
             }
             Err(e) => {
                 eprintln!(

--- a/src/commands/sw_logs.rs
+++ b/src/commands/sw_logs.rs
@@ -87,12 +87,13 @@ pub async fn collect_sw_logs(
                     .as_array()
                     .map(|arr| {
                         arr.iter()
-                            .map(|arg| {
-                                arg["value"]
-                                    .as_str()
-                                    .or_else(|| arg["description"].as_str())
-                                    .unwrap_or("<object>")
-                                    .to_string()
+                            .map(|arg| match arg.get("value") {
+                                // String primitives: emit the raw text (no quotes).
+                                Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
+                                // Other primitives (number, bool, null): stringify directly.
+                                Some(v) => v.to_string(),
+                                // Objects have no `value` — fall back to their description.
+                                None => arg["description"].as_str().unwrap_or("<object>").to_string(),
                             })
                             .collect()
                     })

--- a/src/commands/sw_logs.rs
+++ b/src/commands/sw_logs.rs
@@ -36,6 +36,7 @@ pub async fn collect_sw_logs(
         ));
     }
 
+    let mut warnings = Vec::new();
     let mut sessions = Vec::new();
     for target in &sw_targets {
         match client.attach_to_target(&target.target_id).await {
@@ -48,19 +49,19 @@ pub async fn collect_sw_logs(
                         sessions.push(((*target).clone(), session_id));
                     }
                     Err(e) => {
-                        eprintln!(
-                            "Warning: failed to enable Runtime for service worker {}: {e}",
+                        warnings.push(format!(
+                            "Failed to enable Runtime for service worker {}: {e}",
                             target.url
-                        );
+                        ));
                         let _ = client.detach_from_target(&session_id).await;
                     }
                 }
             }
             Err(e) => {
-                eprintln!(
-                    "Warning: failed to attach to service worker {}: {e}",
+                warnings.push(format!(
+                    "Failed to attach to service worker {}: {e}",
                     target.url
-                );
+                ));
             }
         }
     }
@@ -68,9 +69,12 @@ pub async fn collect_sw_logs(
     // Every attach/Runtime.enable failed: there are no sessions to collect from,
     // so block-reading for the full window would just stall the CLI for nothing.
     if sessions.is_empty() {
-        return Ok(CommandResult::output(
-            "Failed to attach to any extension service workers.".to_string(),
-        ));
+        let mut err = "Failed to attach to any extension service workers.".to_string();
+        if !warnings.is_empty() {
+            err.push_str("\nDetails:\n  ");
+            err.push_str(&warnings.join("\n  "));
+        }
+        return Ok(CommandResult::output(err));
     }
 
     let events_result = client.read_events_for(duration_ms).await;
@@ -100,25 +104,8 @@ pub async fn collect_sw_logs(
         match method {
             "Runtime.consoleAPICalled" => {
                 let msg_type = params["type"].as_str().unwrap_or("log");
-                let args: Vec<String> = params["args"]
-                    .as_array()
-                    .map(|arr| {
-                        arr.iter()
-                            .map(|arg| match arg.get("value") {
-                                // String primitives: emit the raw text (no quotes).
-                                Some(v) if v.is_string() => v.as_str().unwrap_or("").to_string(),
-                                // Other primitives (number, bool, null): stringify directly.
-                                Some(v) => v.to_string(),
-                                // Objects have no `value` — fall back to their description.
-                                None => arg["description"]
-                                    .as_str()
-                                    .unwrap_or("<object>")
-                                    .to_string(),
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let text = args.join(" ");
+                let args = params["args"].as_array().map(|v| v.as_slice()).unwrap_or(&[]);
+                let text = crate::cdp::join_console_args(args);
 
                 messages.push(json!({
                     "extensionId": ext_id,
@@ -145,11 +132,17 @@ pub async fn collect_sw_logs(
 
     if format.is_text() {
         if messages.is_empty() {
-            return Ok(CommandResult::output(
-                "No service worker logs collected.".to_string(),
-            ));
+            let mut out = "No service worker logs collected.".to_string();
+            if !warnings.is_empty() {
+                out.push_str("\n\nWarnings:\n  ");
+                out.push_str(&warnings.join("\n  "));
+            }
+            return Ok(CommandResult::output(out));
         }
         let mut out = String::new();
+        if !warnings.is_empty() {
+            writeln!(out, "Warnings:\n  {}\n", warnings.join("\n  ")).unwrap();
+        }
         for msg in &messages {
             let ext_id = msg["extensionId"].as_str().unwrap_or("?");
             let msg_type = msg["type"].as_str().unwrap_or("?");
@@ -158,7 +151,10 @@ pub async fn collect_sw_logs(
         }
         Ok(CommandResult::output(out))
     } else {
-        let value = serde_json::to_value(&messages)?;
+        let value = json!({
+            "messages": messages,
+            "warnings": warnings,
+        });
         Ok(CommandResult::output(format_structured(&value, format)?))
     }
 }

--- a/src/commands/sw_logs.rs
+++ b/src/commands/sw_logs.rs
@@ -56,7 +56,7 @@ pub async fn collect_sw_logs(
         }
     }
 
-    let events = client.read_events_for(duration_ms).await?;
+    let events_result = client.read_events_for(duration_ms).await;
 
     for (_, session_id) in &sessions {
         let _ = client
@@ -65,17 +65,18 @@ pub async fn collect_sw_logs(
         let _ = client.detach_from_target(session_id).await;
     }
 
+    let events = events_result?;
+
     let mut messages = Vec::new();
     for event in &events {
         let method = event["method"].as_str().unwrap_or("");
         let params = &event["params"];
         let session_id = event["sessionId"].as_str().unwrap_or("");
 
-        let source = sessions
-            .iter()
-            .find(|(_, sid)| sid == session_id)
-            .map(|(t, _)| t.url.as_str())
-            .unwrap_or("unknown");
+        let source = match sessions.iter().find(|(_, sid)| sid == session_id) {
+            Some((t, _)) => t.url.as_str(),
+            None => continue,  // Skip events not from service worker sessions
+        };
 
         let ext_id = extract_extension_id(source).unwrap_or_default();
 
@@ -147,4 +148,43 @@ fn extract_extension_id(url: &str) -> Option<String> {
     let rest = url.strip_prefix(EXTENSION_PREFIX)?;
     let slash = rest.find('/').unwrap_or(rest.len());
     Some(rest[..slash].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_extension_id_with_path() {
+        let url = "chrome-extension://abc123def/background.js";
+        assert_eq!(extract_extension_id(url), Some("abc123def".to_string()));
+    }
+
+    #[test]
+    fn extract_extension_id_no_path() {
+        let url = "chrome-extension://abc123def";
+        assert_eq!(extract_extension_id(url), Some("abc123def".to_string()));
+    }
+
+    #[test]
+    fn extract_extension_id_trailing_slash() {
+        let url = "chrome-extension://abc123def/";
+        assert_eq!(extract_extension_id(url), Some("abc123def".to_string()));
+    }
+
+    #[test]
+    fn extract_extension_id_not_extension_url() {
+        assert_eq!(extract_extension_id("https://example.com"), None);
+        assert_eq!(extract_extension_id("http://foo.bar/abc123"), None);
+    }
+
+    #[test]
+    fn extract_extension_id_empty_string() {
+        assert_eq!(extract_extension_id(""), None);
+    }
+
+    #[test]
+    fn extract_extension_id_prefix_only() {
+        assert_eq!(extract_extension_id("chrome-extension://"), Some("".to_string()));
+    }
 }

--- a/src/commands/sw_logs.rs
+++ b/src/commands/sw_logs.rs
@@ -18,9 +18,7 @@ pub async fn collect_sw_logs(
 
     let sw_targets: Vec<_> = targets
         .iter()
-        .filter(|t| {
-            t.target_type == "service_worker" && t.url.starts_with(EXTENSION_PREFIX)
-        })
+        .filter(|t| t.target_type == "service_worker" && t.url.starts_with(EXTENSION_PREFIX))
         .filter(|t| {
             if let Some(filter_id) = extension_id_filter {
                 extract_extension_id(&t.url)
@@ -75,7 +73,7 @@ pub async fn collect_sw_logs(
 
         let source = match sessions.iter().find(|(_, sid)| sid == session_id) {
             Some((t, _)) => t.url.as_str(),
-            None => continue,  // Skip events not from service worker sessions
+            None => continue, // Skip events not from service worker sessions
         };
 
         let ext_id = extract_extension_id(source).unwrap_or_default();
@@ -93,7 +91,10 @@ pub async fn collect_sw_logs(
                                 // Other primitives (number, bool, null): stringify directly.
                                 Some(v) => v.to_string(),
                                 // Objects have no `value` — fall back to their description.
-                                None => arg["description"].as_str().unwrap_or("<object>").to_string(),
+                                None => arg["description"]
+                                    .as_str()
+                                    .unwrap_or("<object>")
+                                    .to_string(),
                             })
                             .collect()
                     })
@@ -110,9 +111,7 @@ pub async fn collect_sw_logs(
             "Runtime.exceptionThrown" => {
                 let details = &params["exceptionDetails"];
                 let text = details["text"].as_str().unwrap_or("Unknown error");
-                let description = details["exception"]["description"]
-                    .as_str()
-                    .unwrap_or(text);
+                let description = details["exception"]["description"].as_str().unwrap_or(text);
 
                 messages.push(json!({
                     "extensionId": ext_id,
@@ -186,6 +185,9 @@ mod tests {
 
     #[test]
     fn extract_extension_id_prefix_only() {
-        assert_eq!(extract_extension_id("chrome-extension://"), Some("".to_string()));
+        assert_eq!(
+            extract_extension_id("chrome-extension://"),
+            Some("".to_string())
+        );
     }
 }

--- a/src/commands/sw_logs.rs
+++ b/src/commands/sw_logs.rs
@@ -65,6 +65,14 @@ pub async fn collect_sw_logs(
         }
     }
 
+    // Every attach/Runtime.enable failed: there are no sessions to collect from,
+    // so block-reading for the full window would just stall the CLI for nothing.
+    if sessions.is_empty() {
+        return Ok(CommandResult::output(
+            "Failed to attach to any extension service workers.".to_string(),
+        ));
+    }
+
     let events_result = client.read_events_for(duration_ms).await;
 
     for (_, session_id) in &sessions {

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -2,13 +2,14 @@ use anyhow::{bail, Result};
 use serde_json::json;
 
 use crate::cdp::CdpClient;
+use crate::format::{format_structured, OutputFormat};
 use crate::result::CommandResult;
 
 /// List third-party DevTools tools registered via __dtmcp on the page.
 pub async fn list_3p_tools(
     client: &mut CdpClient,
     session_id: &str,
-    json_output: bool,
+    format: OutputFormat,
 ) -> Result<CommandResult> {
     let expr = r#"(() => {
         const dtmcp = window.__dtmcp;
@@ -56,8 +57,9 @@ pub async fn list_3p_tools(
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Failed to list third-party tools"))?;
 
-    if json_output {
-        Ok(CommandResult::output(val_str.to_string()))
+    if !format.is_text() {
+        let val: serde_json::Value = serde_json::from_str(val_str)?;
+        Ok(CommandResult::output(format_structured(&val, format)?))
     } else {
         let val: serde_json::Value = serde_json::from_str(val_str)?;
         let groups = val["groups"]
@@ -105,7 +107,7 @@ pub async fn execute_3p_tool(
     session_id: &str,
     name: &str,
     params: Option<&str>,
-    json_output: bool,
+    format: OutputFormat,
 ) -> Result<CommandResult> {
     let params_json = params.unwrap_or("{}");
     // Basic validation of params
@@ -160,8 +162,11 @@ pub async fn execute_3p_tool(
         bail!("Tool execution error: {err}");
     }
 
-    if json_output {
-        Ok(CommandResult::output(val["result"].to_string()))
+    if !format.is_text() {
+        Ok(CommandResult::output(format_structured(
+            &val["result"],
+            format,
+        )?))
     } else {
         Ok(CommandResult::output(format!(
             "Successfully executed tool '{}'. Result:\n{}",

--- a/src/format.rs
+++ b/src/format.rs
@@ -46,3 +46,115 @@ pub fn format_structured(value: &Value, format: OutputFormat) -> Result<String> 
         OutputFormat::Text => Ok(serde_json::to_string_pretty(value)?),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn from_flags_text_default() {
+        assert_eq!(OutputFormat::from_flags(false, false), OutputFormat::Text);
+    }
+
+    #[test]
+    fn from_flags_json() {
+        assert_eq!(OutputFormat::from_flags(true, false), OutputFormat::Json);
+    }
+
+    #[test]
+    fn from_flags_toon_wins_over_json() {
+        // toon takes precedence when both are set (the CLI enforces mutual
+        // exclusivity, but from_flags should have a defined precedence)
+        assert_eq!(OutputFormat::from_flags(true, true), OutputFormat::Toon);
+    }
+
+    #[test]
+    fn is_flags() {
+        assert!(OutputFormat::Text.is_text());
+        assert!(OutputFormat::Json.is_json());
+        assert!(OutputFormat::Toon.is_toon());
+        assert!(!OutputFormat::Text.is_json());
+        assert!(!OutputFormat::Json.is_text());
+    }
+
+    #[test]
+    fn format_structured_json_produces_pretty_json() {
+        let v = json!({"a": 1, "b": [2, 3]});
+        let out = format_structured(&v, OutputFormat::Json).unwrap();
+        // Contains indentation (pretty-printed)
+        assert!(out.contains("  \"a\": 1"));
+        // Round-trips back to the same Value
+        let parsed: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(parsed, v);
+    }
+
+    #[test]
+    fn format_structured_toon_is_compact() {
+        let v = json!([{"name": "a", "value": 1}, {"name": "b", "value": 2}]);
+        let toon_out = format_structured(&v, OutputFormat::Toon).unwrap();
+        let json_out = format_structured(&v, OutputFormat::Json).unwrap();
+        // TOON should be shorter than pretty-printed JSON
+        assert!(
+            toon_out.len() < json_out.len(),
+            "TOON ({}) should be shorter than JSON ({})",
+            toon_out.len(),
+            json_out.len()
+        );
+    }
+
+    #[test]
+    fn format_structured_text_default_matches_json() {
+        let v = json!({"x": "hello"});
+        let text = format_structured(&v, OutputFormat::Text).unwrap();
+        let json = format_structured(&v, OutputFormat::Json).unwrap();
+        assert_eq!(text, json);
+    }
+}
+
+#[cfg(test)]
+mod daemon_request_format_tests {
+    use crate::format::OutputFormat;
+    use crate::protocol::DaemonRequest;
+    use serde_json::json;
+
+    fn make_req(
+        json_output: bool,
+        output_format: Option<OutputFormat>,
+    ) -> DaemonRequest {
+        DaemonRequest {
+            command: "list-pages".to_string(),
+            args: json!({}),
+            page: None,
+            target: None,
+            json_output,
+            output_format,
+            block_url: vec![],
+            unblock_url: vec![],
+        }
+    }
+
+    #[test]
+    fn format_default_is_text() {
+        let req = make_req(false, None);
+        assert_eq!(req.format(), OutputFormat::Text);
+    }
+
+    #[test]
+    fn format_legacy_json_output_bool() {
+        let req = make_req(true, None);
+        assert_eq!(req.format(), OutputFormat::Json);
+    }
+
+    #[test]
+    fn format_output_format_wins_over_legacy() {
+        let req = make_req(true, Some(OutputFormat::Toon));
+        assert_eq!(req.format(), OutputFormat::Toon);
+    }
+
+    #[test]
+    fn format_output_format_none_uses_default() {
+        let req = make_req(false, Some(OutputFormat::Text));
+        assert_eq!(req.format(), OutputFormat::Text);
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -118,10 +118,7 @@ mod daemon_request_format_tests {
     use crate::protocol::DaemonRequest;
     use serde_json::json;
 
-    fn make_req(
-        json_output: bool,
-        output_format: Option<OutputFormat>,
-    ) -> DaemonRequest {
+    fn make_req(json_output: bool, output_format: Option<OutputFormat>) -> DaemonRequest {
         DaemonRequest {
             command: "list-pages".to_string(),
             args: json!({}),

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,48 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutputFormat {
+    #[default]
+    Text,
+    Json,
+    Toon,
+}
+
+impl OutputFormat {
+    pub fn from_flags(json: bool, toon: bool) -> Self {
+        if toon {
+            OutputFormat::Toon
+        } else if json {
+            OutputFormat::Json
+        } else {
+            OutputFormat::Text
+        }
+    }
+
+    pub fn is_text(self) -> bool {
+        self == OutputFormat::Text
+    }
+
+    pub fn is_json(self) -> bool {
+        self == OutputFormat::Json
+    }
+
+    pub fn is_toon(self) -> bool {
+        self == OutputFormat::Toon
+    }
+}
+
+/// Encode a serde_json::Value as TOON or pretty-printed JSON.
+pub fn format_structured(value: &Value, format: OutputFormat) -> Result<String> {
+    match format {
+        OutputFormat::Json => Ok(serde_json::to_string_pretty(value)?),
+        OutputFormat::Toon => {
+            let options = toon_format::EncodeOptions::default();
+            Ok(toon_format::encode(value, &options)?)
+        }
+        OutputFormat::Text => Ok(serde_json::to_string_pretty(value)?),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod constants;
 pub mod daemon;
 pub mod error;
+pub mod format;
 pub mod friendly;
 pub mod protocol;
 pub mod result;
@@ -44,8 +45,22 @@ pub struct Cli {
     pub target: Option<String>,
 
     /// Output as JSON
-    #[arg(long, global = true)]
+    #[arg(long, global = true, conflicts_with = "toon")]
     pub json: bool,
+
+    /// Output as TOON (Token-Oriented Object Notation — compact encoding for LLMs)
+    #[arg(long, global = true, conflicts_with = "json")]
+    pub toon: bool,
+
+    /// Add URL pattern to the daemon's network block list (e.g. "*.png").
+    /// Repeatable. Persisted in daemon memory until cleared or --allow-url'd.
+    #[arg(long, global = true)]
+    pub block_url: Vec<String>,
+
+    /// Remove URL pattern from the daemon's network block list (allow it).
+    /// Repeatable.
+    #[arg(long, global = true)]
+    pub allow_url: Vec<String>,
 
     #[command(subcommand)]
     pub command: Commands,
@@ -152,7 +167,7 @@ pub enum Commands {
         #[arg(long, short)]
         output: Option<String>,
         /// Track URL changes caused by this evaluation (adds two extra CDP round-trips)
-        #[arg(long, short = 't')]
+        #[arg(long)]
         track_navigation: bool,
     },
 
@@ -212,6 +227,18 @@ pub enum Commands {
         /// Clear all emulation overrides
         #[arg(long)]
         clear_all: bool,
+        /// Add URL pattern to block list (e.g. "*.png", "cdn.example.com/*"). Repeatable.
+        #[arg(long)]
+        block_url: Vec<String>,
+        /// Remove URL pattern from block list (allow it). Repeatable.
+        #[arg(long)]
+        allow_url: Vec<String>,
+        /// Clear network blocklist only
+        #[arg(long)]
+        clear_blocks: bool,
+        /// Clear allowed network URLs only (symmetry alias)
+        #[arg(long)]
+        clear_allows: bool,
     },
 
     /// Wait for text to appear on the page
@@ -233,14 +260,56 @@ pub enum Commands {
         /// JSON-stringified parameters for the tool
         params: Option<String>,
     },
+
+    /// Collect console messages and exceptions from the page
+    Console {
+        /// Duration in ms for live collection. Omit or 0 to drain accumulated events instantly.
+        #[arg(long, short, default_value_t = 0)]
+        duration: u64,
+        /// Filter by message type (e.g. error, warning, log, info). Repeatable.
+        #[arg(long)]
+        r#type: Vec<String>,
+    },
+
+    /// Collect network requests from the page
+    Network {
+        /// Duration in ms for live collection. Omit or 0 to drain accumulated events instantly.
+        #[arg(long, short, default_value_t = 0)]
+        duration: u64,
+        /// Filter by resource type (e.g. document, xhr, fetch, script, stylesheet, image). Repeatable.
+        #[arg(long)]
+        r#type: Vec<String>,
+    },
+
+    /// Collect console logs from extension service workers
+    #[command(name = "sw-logs")]
+    SwLogs {
+        /// Duration in milliseconds to collect logs (default: 3000)
+        #[arg(long, short, default_value_t = 3000)]
+        duration: u64,
+        /// Filter by extension ID. If omitted, collects from all extensions.
+        #[arg(long)]
+        extension_id: Option<String>,
+    },
+
+    /// Stop the background daemon process
+    #[command(name = "kill-daemon")]
+    KillDaemon,
 }
 
 impl Cli {
+    pub fn output_format(&self) -> format::OutputFormat {
+        format::OutputFormat::from_flags(self.json, self.toon)
+    }
+
     /// Whether this command operates at the browser level (no page session needed).
     fn is_browser_level(&self) -> bool {
         matches!(
             self.command,
-            Commands::ListPages | Commands::NewPage { .. }
+            Commands::ListPages
+                | Commands::NewPage { .. }
+                | Commands::SwLogs { .. }
+                | Commands::KillDaemon
         )
     }
 
@@ -265,6 +334,10 @@ impl Cli {
             Commands::WaitFor { .. } => "wait-for",
             Commands::List3pTools => "list-3p-tools",
             Commands::Execute3pTool { .. } => "execute-3p-tool",
+            Commands::Console { .. } => "console",
+            Commands::Network { .. } => "network",
+            Commands::SwLogs { .. } => "sw-logs",
+            Commands::KillDaemon => "kill-daemon",
         }
     }
 }
@@ -368,9 +441,13 @@ fn build_request(cli: &Cli) -> DaemonRequest {
             clear_viewport,
             clear_geolocation,
             clear_all,
+            block_url,
+            allow_url,
+            clear_blocks,
+            clear_allows,
         } => (
             "emulate",
-            json!({"viewport": viewport, "device_scale_factor": device_scale_factor, "mobile": mobile, "geolocation": geolocation, "accuracy": accuracy, "clear_viewport": clear_viewport, "clear_geolocation": clear_geolocation, "clear_all": clear_all}),
+            json!({"viewport": viewport, "device_scale_factor": device_scale_factor, "mobile": mobile, "geolocation": geolocation, "accuracy": accuracy, "clear_viewport": clear_viewport, "clear_geolocation": clear_geolocation, "clear_all": clear_all, "block_url": block_url, "allow_url": allow_url, "clear_blocks": clear_blocks, "clear_allows": clear_allows}),
         ),
         Commands::WaitFor { text, timeout } => {
             ("wait-for", json!({"text": text, "timeout": timeout}))
@@ -379,6 +456,20 @@ fn build_request(cli: &Cli) -> DaemonRequest {
         Commands::Execute3pTool { name, params } => {
             ("execute-3p-tool", json!({"name": name, "params": params}))
         }
+        Commands::Console { duration, r#type } => {
+            ("console", json!({"duration": duration, "type": r#type}))
+        }
+        Commands::Network { duration, r#type } => {
+            ("network", json!({"duration": duration, "type": r#type}))
+        }
+        Commands::SwLogs {
+            duration,
+            extension_id,
+        } => (
+            "sw-logs",
+            json!({"duration": duration, "extension_id": extension_id}),
+        ),
+        Commands::KillDaemon => ("kill-daemon", json!({})),
     };
 
     DaemonRequest {
@@ -387,6 +478,9 @@ fn build_request(cli: &Cli) -> DaemonRequest {
         page: cli.page,
         target: cli.target.clone(),
         json_output: cli.json,
+        output_format: Some(cli.output_format()),
+        block_url: cli.block_url.clone(),
+        allow_url: cli.allow_url.clone(),
     }
 }
 
@@ -464,6 +558,43 @@ pub async fn run() -> Result<()> {
         }
     };
 
+    // Handle kill-daemon without connecting to Chrome
+    if matches!(cli.command, Commands::KillDaemon) {
+        let pid_path = protocol::pid_path();
+        let sock_path = protocol::socket_path();
+        match std::fs::read_to_string(&pid_path) {
+            Ok(pid_str) => {
+                let pid: u32 = pid_str.trim().parse().map_err(|_| {
+                    anyhow::anyhow!("Invalid PID in {}", pid_path.display())
+                })?;
+                #[cfg(unix)]
+                {
+                    use std::process::Command;
+                    let status = Command::new("kill")
+                        .arg(pid.to_string())
+                        .status()?;
+                    if status.success() {
+                        let _ = std::fs::remove_file(&sock_path);
+                        let _ = std::fs::remove_file(&pid_path);
+                        println!("Daemon (PID {pid}) stopped.");
+                    } else {
+                        let _ = std::fs::remove_file(&sock_path);
+                        let _ = std::fs::remove_file(&pid_path);
+                        println!("Daemon (PID {pid}) was not running. Cleaned up stale files.");
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    println!("kill-daemon is only supported on Unix systems.");
+                }
+            }
+            Err(_) => {
+                println!("No daemon running (PID file not found).");
+            }
+        }
+        return Ok(());
+    }
+
     let ws_url = browser::resolve_ws_url(
         cli.ws_endpoint.as_deref(),
         cli.user_data_dir.as_deref(),
@@ -527,7 +658,9 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
 
     if is_browser {
         return match &cli.command {
-            Commands::ListPages => commands::pages::list_pages(&mut client, cli.json).await,
+            Commands::ListPages => {
+                commands::pages::list_pages(&mut client, cli.output_format()).await
+            }
             Commands::NewPage {
                 url,
                 viewport,
@@ -546,6 +679,10 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                     clear_viewport: false,
                     clear_geolocation: false,
                     clear_all: false,
+                    block_url: Vec::new(),
+                    allow_url: Vec::new(),
+                    clear_blocks: false,
+                    clear_allows: false,
                 };
                 params.validate()?;
 
@@ -555,6 +692,18 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                     None
                 };
                 commands::pages::new_page(&mut client, url, params, extra_headers.as_deref()).await
+            }
+            Commands::SwLogs {
+                duration,
+                extension_id,
+            } => {
+                commands::sw_logs::collect_sw_logs(
+                    &mut client,
+                    *duration,
+                    extension_id.as_deref(),
+                    cli.output_format(),
+                )
+                .await
             }
             _ => unreachable!(),
         };
@@ -626,6 +775,10 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_viewport: false,
                 clear_geolocation: false,
                 clear_all: *clear_all,
+                block_url: Vec::new(),
+                allow_url: Vec::new(),
+                clear_blocks: false,
+                clear_allows: false,
             };
             params.validate()?;
 
@@ -670,7 +823,7 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 &mut client,
                 &session_id,
                 expression,
-                cli.json,
+                cli.output_format(),
                 output.as_deref(),
                 *track_navigation,
             )
@@ -695,8 +848,13 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
             commands::input::hover(&mut client, &session_id, selector).await
         }
         Commands::Snapshot { output } => {
-            commands::snapshot::take_snapshot(&mut client, &session_id, cli.json, output.as_deref())
-                .await
+            commands::snapshot::take_snapshot(
+                &mut client,
+                &session_id,
+                cli.output_format(),
+                output.as_deref(),
+            )
+            .await
         }
         Commands::Emulate {
             viewport,
@@ -707,6 +865,10 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
             clear_viewport,
             clear_geolocation,
             clear_all,
+            block_url,
+            allow_url,
+            clear_blocks,
+            clear_allows,
         } => {
             let params = commands::emulation::EmulateParams {
                 viewport: viewport.clone(),
@@ -717,6 +879,10 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_viewport: *clear_viewport,
                 clear_geolocation: *clear_geolocation,
                 clear_all: *clear_all,
+                block_url: block_url.clone(),
+                allow_url: allow_url.clone(),
+                clear_blocks: *clear_blocks,
+                clear_allows: *clear_allows,
             };
             params.validate()?;
             commands::emulation::emulate(&mut client, &session_id, params)
@@ -726,7 +892,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
             commands::pages::wait_for(&mut client, &session_id, text, *timeout).await
         }
         Commands::List3pTools => {
-            commands::third_party::list_3p_tools(&mut client, &session_id, cli.json).await
+            commands::third_party::list_3p_tools(&mut client, &session_id, cli.output_format())
+                .await
         }
         Commands::Execute3pTool { name, params } => {
             commands::third_party::execute_3p_tool(
@@ -734,7 +901,27 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 &session_id,
                 name,
                 params.as_deref(),
-                cli.json,
+                cli.output_format(),
+            )
+            .await
+        }
+        Commands::Console { duration, r#type } => {
+            commands::console::collect_console(
+                &mut client,
+                &session_id,
+                *duration,
+                r#type.clone(),
+                cli.output_format(),
+            )
+            .await
+        }
+        Commands::Network { duration, r#type } => {
+            commands::network::collect_network(
+                &mut client,
+                &session_id,
+                *duration,
+                r#type.clone(),
+                cli.output_format(),
             )
             .await
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -618,8 +618,13 @@ pub async fn run() -> Result<()> {
                 println!("No daemon running (PID file not found).");
             }
             Err(e) => {
-                eprintln!("Failed to read PID file {}: {}", pid_path.display(), e);
-                std::process::exit(1);
+                // Surface via the standard error path (uniform formatting,
+                // telemetry flush, typed exit code) — matching the EPERM
+                // signal-failure case above rather than exiting directly.
+                return Err(anyhow::anyhow!(
+                    "Failed to read PID file {}: {e}",
+                    pid_path.display()
+                ));
             }
         }
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,11 +559,24 @@ pub async fn run() -> Result<()> {
                     .map_err(|_| anyhow::anyhow!("Invalid PID in {}", pid_path.display()))?;
                 #[cfg(unix)]
                 {
+                    // Guard against a PID that doesn't fit in libc::pid_t (a
+                    // signed 32-bit integer on POSIX). The OS never produces such
+                    // PIDs, but a corrupted PID file could, and the cast below
+                    // would silently wrap to a negative number — which kill()
+                    // interprets as "signal all processes in process group -pid",
+                    // potentially killing unrelated processes.
+                    let pid_i32: i32 = i32::try_from(pid).map_err(|_| {
+                        anyhow::anyhow!(
+                            "PID {} in {} exceeds libc::pid_t; refusing to signal",
+                            pid,
+                            pid_path.display()
+                        )
+                    })?;
                     // Signal the process directly via libc to avoid shelling out
                     // to /usr/bin/kill. A return of 0 means the signal was
                     // delivered; -1 with errno ESRCH means the process is gone
                     // (and the PID file was stale).
-                    let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+                    let ret = unsafe { libc::kill(pid_i32 as libc::pid_t, libc::SIGTERM) };
                     if ret == 0 {
                         // Signal delivered — daemon is shutting down; clean up.
                         let _ = std::fs::remove_file(&sock_path);
@@ -682,6 +695,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                     clear_viewport: false,
                     clear_geolocation: false,
                     clear_all: false,
+                    // URL blocking is daemon-only state; new-page in direct mode
+                    // has no persistent session to apply it to.
                     block_url: Vec::new(),
                     unblock_url: Vec::new(),
                     clear_blocks: false,
@@ -784,6 +799,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_viewport: false,
                 clear_geolocation: false,
                 clear_all: *clear_all,
+                // URL blocking is daemon-only state; navigate in direct mode has
+                // no persistent session to apply it to.
                 block_url: Vec::new(),
                 unblock_url: Vec::new(),
                 clear_blocks: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,14 +53,13 @@ pub struct Cli {
     pub toon: bool,
 
     /// Add URL pattern to the daemon's network block list (e.g. "*.png").
-    /// Repeatable. Persisted in daemon memory until cleared or --allow-url'd.
+    /// Repeatable. Persisted in daemon memory until un-blocked or cleared.
     #[arg(long, global = true)]
     pub block_url: Vec<String>,
 
-    /// Remove URL pattern from the daemon's network block list (allow it).
-    /// Repeatable.
+    /// Un-block a previously blocked URL pattern. Repeatable.
     #[arg(long, global = true)]
-    pub allow_url: Vec<String>,
+    pub unblock_url: Vec<String>,
 
     #[command(subcommand)]
     pub command: Commands,
@@ -230,15 +229,12 @@ pub enum Commands {
         /// Add URL pattern to block list (e.g. "*.png", "cdn.example.com/*"). Repeatable.
         #[arg(long)]
         block_url: Vec<String>,
-        /// Remove URL pattern from block list (allow it). Repeatable.
+        /// Un-block a previously blocked URL pattern. Repeatable.
         #[arg(long)]
-        allow_url: Vec<String>,
+        unblock_url: Vec<String>,
         /// Clear network blocklist only
         #[arg(long)]
         clear_blocks: bool,
-        /// Clear allowed network URLs only (symmetry alias)
-        #[arg(long)]
-        clear_allows: bool,
     },
 
     /// Wait for text to appear on the page
@@ -263,7 +259,8 @@ pub enum Commands {
 
     /// Collect console messages and exceptions from the page
     Console {
-        /// Duration in ms for live collection. Omit or 0 to drain accumulated events instantly.
+        /// Duration in ms for live collection (events remain available to a later drain).
+        /// Omit or 0 to drain accumulated events instantly.
         #[arg(long, short, default_value_t = 0)]
         duration: u64,
         /// Filter by message type (e.g. error, warning, log, info). Repeatable.
@@ -273,7 +270,8 @@ pub enum Commands {
 
     /// Collect network requests from the page
     Network {
-        /// Duration in ms for live collection. Omit or 0 to drain accumulated events instantly.
+        /// Duration in ms for live collection (events remain available to a later drain).
+        /// Omit or 0 to drain accumulated events instantly.
         #[arg(long, short, default_value_t = 0)]
         duration: u64,
         /// Filter by resource type (e.g. document, xhr, fetch, script, stylesheet, image). Repeatable.
@@ -442,12 +440,11 @@ fn build_request(cli: &Cli) -> DaemonRequest {
             clear_geolocation,
             clear_all,
             block_url,
-            allow_url,
+            unblock_url,
             clear_blocks,
-            clear_allows,
         } => (
             "emulate",
-            json!({"viewport": viewport, "device_scale_factor": device_scale_factor, "mobile": mobile, "geolocation": geolocation, "accuracy": accuracy, "clear_viewport": clear_viewport, "clear_geolocation": clear_geolocation, "clear_all": clear_all, "block_url": block_url, "allow_url": allow_url, "clear_blocks": clear_blocks, "clear_allows": clear_allows}),
+            json!({"viewport": viewport, "device_scale_factor": device_scale_factor, "mobile": mobile, "geolocation": geolocation, "accuracy": accuracy, "clear_viewport": clear_viewport, "clear_geolocation": clear_geolocation, "clear_all": clear_all, "block_url": block_url, "unblock_url": unblock_url, "clear_blocks": clear_blocks}),
         ),
         Commands::WaitFor { text, timeout } => {
             ("wait-for", json!({"text": text, "timeout": timeout}))
@@ -480,7 +477,7 @@ fn build_request(cli: &Cli) -> DaemonRequest {
         json_output: cli.json,
         output_format: Some(cli.output_format()),
         block_url: cli.block_url.clone(),
-        allow_url: cli.allow_url.clone(),
+        unblock_url: cli.unblock_url.clone(),
     }
 }
 
@@ -569,22 +566,27 @@ pub async fn run() -> Result<()> {
                 })?;
                 #[cfg(unix)]
                 {
-                    use std::process::Command;
-                    let status = Command::new("kill")
-                        .arg(pid.to_string())
-                        .status()?;
-                    if status.success() {
-                        let _ = std::fs::remove_file(&sock_path);
-                        let _ = std::fs::remove_file(&pid_path);
+                    // Signal the process directly via libc to avoid shelling out
+                    // to /usr/bin/kill. A return of 0 means the signal was
+                    // delivered; -1 with errno ESRCH means the process is gone
+                    // (and the PID file was stale).
+                    let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
+                    let _ = std::fs::remove_file(&sock_path);
+                    let _ = std::fs::remove_file(&pid_path);
+                    if ret == 0 {
                         println!("Daemon (PID {pid}) stopped.");
                     } else {
-                        let _ = std::fs::remove_file(&sock_path);
-                        let _ = std::fs::remove_file(&pid_path);
-                        println!("Daemon (PID {pid}) was not running. Cleaned up stale files.");
+                        let err = std::io::Error::last_os_error();
+                        if err.raw_os_error() == Some(libc::ESRCH) {
+                            println!("Daemon (PID {pid}) was not running. Cleaned up stale files.");
+                        } else {
+                            eprintln!("Failed to signal daemon (PID {pid}): {err}");
+                        }
                     }
                 }
                 #[cfg(not(unix))]
                 {
+                    let _ = pid;
                     println!("kill-daemon is only supported on Unix systems.");
                 }
             }
@@ -680,9 +682,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                     clear_geolocation: false,
                     clear_all: false,
                     block_url: Vec::new(),
-                    allow_url: Vec::new(),
+                    unblock_url: Vec::new(),
                     clear_blocks: false,
-                    clear_allows: false,
                 };
                 params.validate()?;
 
@@ -776,9 +777,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_geolocation: false,
                 clear_all: *clear_all,
                 block_url: Vec::new(),
-                allow_url: Vec::new(),
+                unblock_url: Vec::new(),
                 clear_blocks: false,
-                clear_allows: false,
             };
             params.validate()?;
 
@@ -866,9 +866,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
             clear_geolocation,
             clear_all,
             block_url,
-            allow_url,
+            unblock_url,
             clear_blocks,
-            clear_allows,
         } => {
             let params = commands::emulation::EmulateParams {
                 viewport: viewport.clone(),
@@ -880,9 +879,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_geolocation: *clear_geolocation,
                 clear_all: *clear_all,
                 block_url: block_url.clone(),
-                allow_url: allow_url.clone(),
+                unblock_url: unblock_url.clone(),
                 clear_blocks: *clear_blocks,
-                clear_allows: *clear_allows,
             };
             params.validate()?;
             commands::emulation::emulate(&mut client, &session_id, params)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,6 +559,12 @@ pub async fn run() -> Result<()> {
                     .map_err(|_| anyhow::anyhow!("Invalid PID in {}", pid_path.display()))?;
                 #[cfg(unix)]
                 {
+                    // Refuse PID 0: kill(0, ...) signals every process in the
+                    // caller's process group — it would take down this CLI and
+                    // its siblings. A corrupted/truncated PID file could read "0".
+                    if pid == 0 {
+                        anyhow::bail!("PID in {} is 0; refusing to signal", pid_path.display());
+                    }
                     // Guard against a PID that doesn't fit in libc::pid_t (a
                     // signed 32-bit integer on POSIX). The OS never produces such
                     // PIDs, but a corrupted PID file could, and the cast below

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,12 @@ pub struct Cli {
     #[arg(long, global = true, conflicts_with = "json")]
     pub toon: bool,
 
-    /// Add URL pattern to the daemon's network block list (e.g. "*.png").
-    /// Repeatable. Persisted in daemon memory until un-blocked or cleared.
-    /// Blocks subresources (images, scripts, fetch/XHR, CDN, trackers); does
-    /// NOT block top-level navigations (a Chrome setBlockedURLs limitation).
+    /// Add URL pattern to the network block list (e.g. "*.png"). Repeatable.
+    /// In daemon mode, persisted in daemon memory (per tab) until un-blocked or
+    /// cleared; in direct mode (no daemon), applied per-invocation to the
+    /// command's session only. Blocks subresources (images, scripts, fetch/XHR,
+    /// CDN, trackers); does NOT block top-level navigations (a Chrome
+    /// setBlockedURLs limitation).
     #[arg(long, global = true)]
     pub block_url: Vec<String>,
 
@@ -703,10 +705,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                     clear_viewport: false,
                     clear_geolocation: false,
                     clear_all: false,
-                    // URL blocking is daemon-only state; new-page in direct mode
-                    // has no persistent session to apply it to.
-                    block_url: Vec::new(),
-                    unblock_url: Vec::new(),
+                    block_url: cli.block_url.clone(),
+                    unblock_url: cli.unblock_url.clone(),
                     clear_blocks: false,
                 };
                 params.validate()?;
@@ -807,10 +807,8 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_viewport: false,
                 clear_geolocation: false,
                 clear_all: *clear_all,
-                // URL blocking is daemon-only state; navigate in direct mode has
-                // no persistent session to apply it to.
-                block_url: Vec::new(),
-                unblock_url: Vec::new(),
+                block_url: cli.block_url.clone(),
+                unblock_url: cli.unblock_url.clone(),
                 clear_blocks: false,
             };
             params.validate()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,8 +614,12 @@ pub async fn run() -> Result<()> {
                     println!("kill-daemon is only supported on Unix systems.");
                 }
             }
-            Err(_) => {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 println!("No daemon running (PID file not found).");
+            }
+            Err(e) => {
+                eprintln!("Failed to read PID file {}: {}", pid_path.display(), e);
+                std::process::exit(1);
             }
         }
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -392,14 +392,12 @@ fn build_request(cli: &Cli) -> DaemonRequest {
                 "extra_headers": extra_headers
             }),
         ),
-        Commands::ClosePage { id_or_index } => (
-            "close-page",
-            json!({ "id_or_index": id_or_index }),
-        ),
-        Commands::SelectPage { id_or_index } => (
-            "select-page",
-            json!({ "id_or_index": id_or_index }),
-        ),
+        Commands::ClosePage { id_or_index } => {
+            ("close-page", json!({ "id_or_index": id_or_index }))
+        }
+        Commands::SelectPage { id_or_index } => {
+            ("select-page", json!({ "id_or_index": id_or_index }))
+        }
         Commands::Screenshot {
             output,
             format,
@@ -525,16 +523,14 @@ pub async fn run() -> Result<()> {
 
             // Show subcommand-specific help when the error is about a subcommand's args
             let mut cmd = Cli::command();
-            let sub_name = std::env::args_os()
-                .skip(1)
-                .find_map(|arg| {
-                    let s = arg.to_string_lossy();
-                    if !s.starts_with('-') && cmd.get_subcommands().any(|c| c.get_name() == s) {
-                        Some(s.into_owned())
-                    } else {
-                        None
-                    }
-                });
+            let sub_name = std::env::args_os().skip(1).find_map(|arg| {
+                let s = arg.to_string_lossy();
+                if !s.starts_with('-') && cmd.get_subcommands().any(|c| c.get_name() == s) {
+                    Some(s.into_owned())
+                } else {
+                    None
+                }
+            });
             match sub_name {
                 Some(name) => {
                     if let Some(sub_cmd) = cmd.find_subcommand_mut(&name) {
@@ -557,9 +553,10 @@ pub async fn run() -> Result<()> {
         let sock_path = protocol::socket_path();
         match std::fs::read_to_string(&pid_path) {
             Ok(pid_str) => {
-                let pid: u32 = pid_str.trim().parse().map_err(|_| {
-                    anyhow::anyhow!("Invalid PID in {}", pid_path.display())
-                })?;
+                let pid: u32 = pid_str
+                    .trim()
+                    .parse()
+                    .map_err(|_| anyhow::anyhow!("Invalid PID in {}", pid_path.display()))?;
                 #[cfg(unix)]
                 {
                     // Signal the process directly via libc to avoid shelling out
@@ -733,10 +730,17 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
     let target_id = target.target_id.clone();
 
     // Special case for browser-level commands that target a specific page but don't need a session
-    if matches!(cli.command, Commands::ClosePage { .. } | Commands::SelectPage { .. }) {
+    if matches!(
+        cli.command,
+        Commands::ClosePage { .. } | Commands::SelectPage { .. }
+    ) {
         return match &cli.command {
-            Commands::ClosePage { .. } => commands::pages::close_page(&mut client, &target_id).await,
-            Commands::SelectPage { .. } => commands::pages::select_page(&mut client, &target_id).await,
+            Commands::ClosePage { .. } => {
+                commands::pages::close_page(&mut client, &target_id).await
+            }
+            Commands::SelectPage { .. } => {
+                commands::pages::select_page(&mut client, &target_id).await
+            }
             _ => unreachable!(),
         };
     }
@@ -886,8 +890,7 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_blocks: *clear_blocks,
             };
             params.validate()?;
-            commands::emulation::emulate(&mut client, &session_id, params)
-                .await
+            commands::emulation::emulate(&mut client, &session_id, params).await
         }
         Commands::WaitFor { text, timeout } => {
             commands::pages::wait_for(&mut client, &session_id, text, *timeout).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -571,16 +571,24 @@ pub async fn run() -> Result<()> {
                     // delivered; -1 with errno ESRCH means the process is gone
                     // (and the PID file was stale).
                     let ret = unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) };
-                    let _ = std::fs::remove_file(&sock_path);
-                    let _ = std::fs::remove_file(&pid_path);
                     if ret == 0 {
+                        // Signal delivered — daemon is shutting down; clean up.
+                        let _ = std::fs::remove_file(&sock_path);
+                        let _ = std::fs::remove_file(&pid_path);
                         println!("Daemon (PID {pid}) stopped.");
                     } else {
                         let err = std::io::Error::last_os_error();
                         if err.raw_os_error() == Some(libc::ESRCH) {
+                            // Process is gone — the PID file was stale; clean up.
+                            let _ = std::fs::remove_file(&sock_path);
+                            let _ = std::fs::remove_file(&pid_path);
                             println!("Daemon (PID {pid}) was not running. Cleaned up stale files.");
                         } else {
-                            eprintln!("Failed to signal daemon (PID {pid}): {err}");
+                            // e.g. EPERM: the daemon may still be running. Leave the
+                            // socket/PID files so it stays reachable.
+                            eprintln!(
+                                "Failed to signal daemon (PID {pid}): {err}. Left socket/PID files in place."
+                            );
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -598,9 +598,9 @@ pub async fn run() -> Result<()> {
                         } else {
                             // e.g. EPERM: the daemon may still be running. Leave the
                             // socket/PID files so it stays reachable.
-                            eprintln!(
+                            return Err(anyhow::anyhow!(
                                 "Failed to signal daemon (PID {pid}): {err}. Left socket/PID files in place."
-                            );
+                            ));
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,8 @@ pub enum Commands {
         /// Omit or 0 to drain accumulated events instantly.
         #[arg(long, short, default_value_t = 0)]
         duration: u64,
-        /// Filter by message type (e.g. error, warning, log, info). Repeatable.
+        /// Filter by message type (e.g. error, warning, log, info). Case-insensitive;
+        /// "warn" is accepted as an alias for "warning". Repeatable.
         #[arg(long)]
         r#type: Vec<String>,
     },
@@ -272,7 +273,8 @@ pub enum Commands {
         /// Omit or 0 to drain accumulated events instantly.
         #[arg(long, short, default_value_t = 0)]
         duration: u64,
-        /// Filter by resource type (e.g. document, xhr, fetch, script, stylesheet, image). Repeatable.
+        /// Filter by resource type (e.g. document, xhr, fetch, script, stylesheet, image).
+        /// Case-insensitive. Repeatable.
         #[arg(long)]
         r#type: Vec<String>,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,18 +779,32 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
 
     let session_id = client.attach_to_target(&target_id).await?;
 
-    // Enable Page domain to receive dialog events for proactive rejection
+    // Extract dialog_action if set (only available on Evaluate command, but
+    // apply it for all commands in direct mode to match daemon behavior)
+    client.dialog_action = match &cli.command {
+        Commands::Evaluate { dialog_action, .. } => dialog_action.clone(),
+        _ => None,
+    };
+
+    // Enable Page domain to receive dialog events for proactive rejection.
+    // Must run before any navigation or interaction triggers a dialog.
     client
         .send_to_target(&session_id, "Page.enable", json!({}))
         .await?;
 
-    // Extract dialog_action if set (only available on Evaluate command, but
-    // apply it for all commands in direct mode to match daemon behavior)
-    let dialog_action = match &cli.command {
-        Commands::Evaluate { dialog_action, .. } => dialog_action.clone(),
-        _ => None,
-    };
-    client.dialog_action = dialog_action;
+    // Apply the global --block-url/--unblock-url flags in direct mode.
+    // Order: skip for emulate (it handles blocks itself), close/select (no session).
+    if !matches!(cli.command, Commands::Emulate { .. } | Commands::ClosePage { .. } | Commands::SelectPage { .. })
+        && (!cli.block_url.is_empty() || !cli.unblock_url.is_empty())
+    {
+        for p in &cli.block_url {
+            if !client.blocklist.contains(p) {
+                client.blocklist.push(p.clone());
+            }
+        }
+        client.blocklist.retain(|b| !cli.unblock_url.contains(b));
+        client.apply_network_rules_internal(&session_id).await?;
+    }
 
     let result = match &cli.command {
         Commands::Navigate {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ pub struct Cli {
 
     /// Add URL pattern to the daemon's network block list (e.g. "*.png").
     /// Repeatable. Persisted in daemon memory until un-blocked or cleared.
+    /// Blocks subresources (images, scripts, fetch/XHR, CDN, trackers); does
+    /// NOT block top-level navigations (a Chrome setBlockedURLs limitation).
     #[arg(long, global = true)]
     pub block_url: Vec<String>,
 
@@ -226,15 +228,11 @@ pub enum Commands {
         /// Clear all emulation overrides
         #[arg(long)]
         clear_all: bool,
-        /// Add URL pattern to block list (e.g. "*.png", "cdn.example.com/*"). Repeatable.
-        #[arg(long)]
-        block_url: Vec<String>,
-        /// Un-block a previously blocked URL pattern. Repeatable.
-        #[arg(long)]
-        unblock_url: Vec<String>,
         /// Clear network blocklist only
         #[arg(long)]
         clear_blocks: bool,
+        // Note: --block-url / --unblock-url are global flags (see `Cli`); they
+        // work on `emulate` via clap's global-arg inheritance.
     },
 
     /// Wait for text to appear on the page
@@ -439,12 +437,10 @@ fn build_request(cli: &Cli) -> DaemonRequest {
             clear_viewport,
             clear_geolocation,
             clear_all,
-            block_url,
-            unblock_url,
             clear_blocks,
         } => (
             "emulate",
-            json!({"viewport": viewport, "device_scale_factor": device_scale_factor, "mobile": mobile, "geolocation": geolocation, "accuracy": accuracy, "clear_viewport": clear_viewport, "clear_geolocation": clear_geolocation, "clear_all": clear_all, "block_url": block_url, "unblock_url": unblock_url, "clear_blocks": clear_blocks}),
+            json!({"viewport": viewport, "device_scale_factor": device_scale_factor, "mobile": mobile, "geolocation": geolocation, "accuracy": accuracy, "clear_viewport": clear_viewport, "clear_geolocation": clear_geolocation, "clear_all": clear_all, "clear_blocks": clear_blocks}),
         ),
         Commands::WaitFor { text, timeout } => {
             ("wait-for", json!({"text": text, "timeout": timeout}))
@@ -873,8 +869,6 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
             clear_viewport,
             clear_geolocation,
             clear_all,
-            block_url,
-            unblock_url,
             clear_blocks,
         } => {
             let params = commands::emulation::EmulateParams {
@@ -886,8 +880,9 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
                 clear_viewport: *clear_viewport,
                 clear_geolocation: *clear_geolocation,
                 clear_all: *clear_all,
-                block_url: block_url.clone(),
-                unblock_url: unblock_url.clone(),
+                // block/unblock come from the global flags, not the subcommand.
+                block_url: cli.block_url.clone(),
+                unblock_url: cli.unblock_url.clone(),
                 clear_blocks: *clear_blocks,
             };
             params.validate()?;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -5,6 +5,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use anyhow::Context;
 
+use crate::format::OutputFormat;
+
 /// Request from CLI client to daemon.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DaemonRequest {
@@ -12,7 +14,29 @@ pub struct DaemonRequest {
     pub args: Value,
     pub page: Option<usize>,
     pub target: Option<String>,
+    #[serde(default)]
     pub json_output: bool,
+    #[serde(default)]
+    pub output_format: Option<OutputFormat>,
+    /// URL patterns to add to the daemon's network blocklist (from global CLI flags).
+    #[serde(default)]
+    pub block_url: Vec<String>,
+    /// URL patterns to remove from the daemon's network blocklist (from global CLI flags).
+    #[serde(default)]
+    pub allow_url: Vec<String>,
+}
+
+impl DaemonRequest {
+    /// Resolve the output format, preferring the new `output_format` field
+    /// and falling back to the legacy `json_output` bool.
+    pub fn format(&self) -> OutputFormat {
+        self.output_format
+            .unwrap_or(if self.json_output {
+                OutputFormat::Json
+            } else {
+                OutputFormat::Text
+            })
+    }
 }
 
 /// Response from daemon to CLI client.

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,7 +23,7 @@ pub struct DaemonRequest {
     pub block_url: Vec<String>,
     /// URL patterns to remove from the daemon's network blocklist (from global CLI flags).
     #[serde(default)]
-    pub allow_url: Vec<String>,
+    pub unblock_url: Vec<String>,
 }
 
 impl DaemonRequest {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -30,12 +30,11 @@ impl DaemonRequest {
     /// Resolve the output format, preferring the new `output_format` field
     /// and falling back to the legacy `json_output` bool.
     pub fn format(&self) -> OutputFormat {
-        self.output_format
-            .unwrap_or(if self.json_output {
-                OutputFormat::Json
-            } else {
-                OutputFormat::Text
-            })
+        self.output_format.unwrap_or(if self.json_output {
+            OutputFormat::Json
+        } else {
+            OutputFormat::Text
+        })
     }
 }
 
@@ -79,8 +78,8 @@ pub async fn write_msg<W: AsyncWriteExt + Unpin>(w: &mut W, data: &[u8]) -> anyh
 pub async fn read_msg<R: AsyncReadExt + Unpin>(r: &mut R) -> anyhow::Result<Vec<u8>> {
     let mut len_buf = [0u8; 4];
     r.read_exact(&mut len_buf).await?;
-    let len = usize::try_from(u32::from_be_bytes(len_buf))
-        .context("Message length overflows usize")?;
+    let len =
+        usize::try_from(u32::from_be_bytes(len_buf)).context("Message length overflows usize")?;
     if len > 64 * 1024 * 1024 {
         anyhow::bail!("Message too large: {len} bytes");
     }

--- a/tests/executor_tests.rs
+++ b/tests/executor_tests.rs
@@ -20,7 +20,7 @@ mod tests {
             json_output: false,
             output_format: None,
             block_url: vec![],
-            allow_url: vec![],
+            unblock_url: vec![],
         };
         assert_eq!(req.command, "list-pages");
 
@@ -32,7 +32,7 @@ mod tests {
             json_output: false,
             output_format: None,
             block_url: vec![],
-            allow_url: vec![],
+            unblock_url: vec![],
         };
         assert_eq!(req.command, "navigate");
 
@@ -44,7 +44,7 @@ mod tests {
             json_output: false,
             output_format: None,
             block_url: vec![],
-            allow_url: vec![],
+            unblock_url: vec![],
         };
         assert_eq!(req.command, "click");
     }

--- a/tests/executor_tests.rs
+++ b/tests/executor_tests.rs
@@ -55,8 +55,8 @@ mod tests {
     /// never get out of sync when CLI flags are added or removed.
     #[test]
     fn test_known_args_sync_with_clap() {
-        use clap::CommandFactory;
         use chrome_devtools_cli::Cli;
+        use clap::CommandFactory;
 
         let cmd = Cli::command();
         for sub in cmd.get_subcommands() {

--- a/tests/executor_tests.rs
+++ b/tests/executor_tests.rs
@@ -18,6 +18,9 @@ mod tests {
             page: None,
             target: None,
             json_output: false,
+            output_format: None,
+            block_url: vec![],
+            allow_url: vec![],
         };
         assert_eq!(req.command, "list-pages");
 
@@ -27,6 +30,9 @@ mod tests {
             page: None,
             target: None,
             json_output: false,
+            output_format: None,
+            block_url: vec![],
+            allow_url: vec![],
         };
         assert_eq!(req.command, "navigate");
 
@@ -36,6 +42,9 @@ mod tests {
             page: None,
             target: None,
             json_output: false,
+            output_format: None,
+            block_url: vec![],
+            allow_url: vec![],
         };
         assert_eq!(req.command, "click");
     }

--- a/tests/telemetry_tests.rs
+++ b/tests/telemetry_tests.rs
@@ -26,12 +26,12 @@ fn test_telemetry_log_command() {
         .collect();
     assert_eq!(log_files.len(), 1, "expected exactly one log file");
 
-    let content = std::fs::read_to_string(log_files[0].path())
-        .expect("should be able to read log file");
+    let content =
+        std::fs::read_to_string(log_files[0].path()).expect("should be able to read log file");
 
     // The entry should be valid JSON with the command we logged
-    let parsed: serde_json::Value = serde_json::from_str(content.trim())
-        .expect("log entry should be valid JSON");
+    let parsed: serde_json::Value =
+        serde_json::from_str(content.trim()).expect("log entry should be valid JSON");
     assert_eq!(parsed["command"], "test-command");
     assert_eq!(parsed["duration_ms"], 42);
     assert_eq!(parsed["success"], true);


### PR DESCRIPTION
- Introduce OutputFormat (Text/Json/Toon) with --toon flag alongside --json. TOON produces compact tabular output for LLM agents (toon-format crate).
- Add `console`, `network`, and `sw-logs` commands for inspecting page console messages, network requests, and extension service worker logs.
- Add persistent CDP session that stays attached to the current page so events accumulate across commands; `console`/`network` drain on demand instead of using blocking --duration windows.
- Add --block-url/--allow-url under `emulate` (+ as global flags) for URL blocking via Network.setBlockedURLs; patterns persist in the daemon.
- Add `kill-daemon` subcommand for stopping the background daemon cleanly.
- Rewrite skill/chrome-devtools/SKILL.md with correct target-name workflow, pattern-based usage examples, and critical gotchas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **New Features**
  * Added `console`, `network`, and `sw-logs` commands with optional type filtering and duration-based live collection (plus quick drain mode).
  * Added `kill-daemon` and persistent CDP event buffering to reuse inspection state across page targets.
* **Improvements**
  * Expanded URL blocking with repeatable `--block-url`/`--unblock-url` and clearing options (`--clear-blocks`/`--clear-all`).
  * Unified output selection via mutually exclusive `--json`/`--toon` across key commands.
* **Documentation**
  * Updated the Chrome DevTools Protocol CLI guide and refreshed README for new commands, output behavior, and blocking semantics.
* **Tests / Bug Fixes**
  * Added coverage for per-tab emulation isolation and improved behavior when closing pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->