### PR TITLE
feat: add read-page command and document.modelContext support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# Chrome DevTools CLI — Agent Guide
+
+## Overview
+
+High-performance Rust CLI that connects to a running Chrome browser via the
+DevTools Protocol. Talks directly to Chrome's CDP WebSocket — no MCP overhead,
+no headless browser stack. One command in, one result out.
+
+## Repository Structure
+
+```
+src/
+├── main.rs           # Entry point + daemon dispatch
+├── lib.rs            # CLI (clap) + command routing
+├── cdp.rs            # Raw CDP over WebSocket (JSON-RPC) + persistent session
+├── browser.rs        # Auto-connect (DevToolsActivePort)
+├── daemon.rs         # Background daemon (persistent connection)
+├── client.rs         # Talks to daemon via Unix socket
+├── protocol.rs       # IPC message types (DaemonRequest / DaemonResponse)
+├── friendly.rs       # Target ID → word-pair names
+├── format.rs         # OutputFormat (text/json/toon) + format_structured
+├── result.rs         # CommandResult type
+├── error.rs          # CLI error types and codes
+├── constants.rs      # Shared constants
+├── telemetry.rs      # Logging and telemetry
+└── commands/
+    ├── executor.rs   # Command dispatch + persistent-session reuse
+    ├── navigate.rs
+    ├── pages.rs      # list/new/close/select/wait-for
+    ├── screenshot.rs
+    ├── snapshot.rs
+    ├── read_page.rs  # read-page (Readability + HTML→Markdown)
+    ├── evaluate.rs
+    ├── input.rs      # click/fill/type/press/hover
+    ├── emulation.rs  # emulate (viewport/geolocation/blocklist)
+    ├── console.rs    # console drain / live collection
+    ├── network.rs    # network drain / live collection
+    ├── sw_logs.rs    # extension service-worker log collection
+    └── third_party.rs # list-3p-tools/execute-3p-tool
+```
+
+## Wiki
+
+Detailed documentation for individual commands:
+
+- [read-page](wiki/read-page.md) — page content extraction as markdown
+
+## Key Concepts
+
+### Daemon Architecture
+
+A background daemon (`/tmp/chrome-devtools-daemon.sock`) keeps a persistent CDP
+WebSocket connection. First CLI invocation spawns it; subsequent commands reuse
+it. 5-minute idle timeout.
+
+### Page Targeting
+
+Every page gets a deterministic friendly name (e.g. `warm-squid`) derived from
+Chrome's internal target ID. Commands should always use `--target <name>` to pin
+to a specific page — page indices shift as tabs are opened/closed.
+
+### Persistent Session
+
+The daemon maintains a persistent CDP session on the active page that
+continuously collects `Network.*` and `Runtime.*` events. `console` and
+`network` commands drain whatever has accumulated since the last call.
+
+### Output Formats
+
+All commands default to human-readable text. `--json` and `--toon` (compact,
+LLM-friendly) produce structured output. Mutually exclusive.
+
+## Build & Test
+
+```bash
+cargo build --release          # Binary: ./target/release/chrome-devtools
+cargo test                      # Run all tests
+cargo test commands::read_page  # Run tests for a specific module
+```
+
+## Coding Conventions
+
+- Comments explain **why**, not what
+- Each command is a pure async function taking `&mut CdpClient`, `session_id`,
+  `OutputFormat`, and command-specific args
+- Pure conversion/formatting logic is extracted into testable functions
+- Tests live in `#[cfg(test)] mod tests` within the same file
+- Error handling uses `anyhow::Result` with descriptive messages
+- CDP calls go through `CdpClient::send_to_target()`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ no headless browser stack. One command in, one result out.
 
 ## Repository Structure
 
-```
+```text
 src/
 ├── main.rs           # Entry point + daemon dispatch
 ├── lib.rs            # CLI (clap) + command routing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -143,6 +152,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -240,7 +255,9 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "dom_smoothie",
  "futures-util",
+ "htmd",
  "libc",
  "serde",
  "serde_json",
@@ -423,6 +440,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +509,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
 ]
 
 [[package]]
@@ -522,6 +583,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "dom_query"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
+dependencies = [
+ "bit-set 0.8.0",
+ "cssparser",
+ "foldhash 0.2.0",
+ "html5ever 0.39.0",
+ "nom",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
+name = "dom_smoothie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8b9b294aabb8010b37c49a07d6f82175152f4927855d534979a38737721875"
+dependencies = [
+ "dom_query",
+ "flagset",
+ "foldhash 0.2.0",
+ "gjson",
+ "html-escape",
+ "once_cell",
+ "phf",
+ "tendril",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,7 +665,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex-automata",
  "regex-syntax",
 ]
@@ -588,6 +698,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +724,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures-core"
@@ -697,6 +819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gjson"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43503cc176394dd30a6525f5f36e838339b8b5619be33ed9a7783841580a97b6"
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +843,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -729,6 +857,46 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "htmd"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever_rcdom",
+ "phf",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
 
 [[package]]
 name = "http"
@@ -939,6 +1107,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.38.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
+dependencies = [
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
+ "tendril",
+ "xml5ever",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,6 +1176,21 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1140,6 +1357,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1461,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -1354,6 +1630,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1698,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1764,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1511,6 +1830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,10 +1858,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -1612,6 +1968,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,7 +2043,7 @@ dependencies = [
  "fancy-regex",
  "lazy_static",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -1857,6 +2223,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2351,18 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -2409,6 +2793,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xml5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "dom_smoothie",
  "futures-util",
  "htmd",
+ "html-escape",
  "libc",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 toon-format = "0.5"
 tokio-tungstenite = "0.24"
+htmd = "0.5.4"
+dom_smoothie = "0.18.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ toon-format = "0.5"
 tokio-tungstenite = "0.24"
 htmd = "0.5.4"
 dom_smoothie = "0.18.0"
+html-escape = "0.2.13"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ You can also use `--page <index>` for quick one-offs, or pass the raw hex target
 |---------|-------------|
 | `screenshot --output <path>` | Save screenshot to file |
 | `screenshot --full-page` | Capture full scrollable page |
+| `read-page` | Read page content as clean markdown (extracts main article) |
+| `read-page --output <path>` | Save markdown to file |
 | `evaluate <expr> [--dialog-action <action>]` | Run JavaScript (optionally handle dialogs: accept, dismiss, or prompt text) |
 | `snapshot` | Accessibility tree dump |
 
@@ -247,10 +249,11 @@ The daemon keeps a persistent CDP session on the current page to:
     ├── navigate.rs
     ├── pages.rs      # list/new/close/select/wait-for
     ├── screenshot.rs
+    ├── snapshot.rs
+    ├── read_page.rs  # read-page (Readability extraction + HTML→Markdown)
     ├── evaluate.rs
     ├── executor.rs   # Command dispatch + persistent-session reuse
     ├── input.rs      # click/fill/type/press/hover
-    ├── snapshot.rs
     ├── emulation.rs  # emulate (viewport/geolocation/blocklist get/set/clear)
     ├── console.rs    # console drain / live collection
     ├── network.rs    # network drain / live collection
@@ -275,6 +278,8 @@ chrome-devtools --target red-snake click "#submit"
 
 # 4. Extract data
 chrome-devtools --target red-snake evaluate "document.title"
+chrome-devtools --target red-snake read-page                    # full article as markdown
+chrome-devtools --target red-snake read-page --json             # with metadata (title, byline, url)
 
 # 5. Inspect what the page did under the hood
 chrome-devtools --target red-snake network      # drain accumulated requests

--- a/skill/chrome-devtools/SKILL.md
+++ b/skill/chrome-devtools/SKILL.md
@@ -56,7 +56,7 @@ chrome-devtools --page 0 navigate https://example.com
 
 - **Navigation**: `navigate`, `navigate --back`, `navigate --forward`, `navigate --reload`
 - **Page management**: `list-pages`, `new-page`, `close-page`, `select-page`
-- **Extraction**: `screenshot`, `snapshot` (accessibility tree), `evaluate` (JavaScript)
+- **Extraction**: `screenshot`, `snapshot` (accessibility tree), `evaluate` (JavaScript), `read-page` (page content as markdown)
 - **Interaction**: `click`, `fill`, `type-text`, `press-key`, `hover`, `click-at`
 - **Emulation**: `emulate` (viewport, mobile, geolocation, URL blocking)
 - **Inspection**: `console` (logs), `network` (requests), `sw-logs` (extension service workers)
@@ -293,6 +293,24 @@ chrome-devtools --target warm-squid list-3p-tools
 chrome-devtools --target warm-squid execute-3p-tool "<tool-name>" '<json-params>'
 ```
 
+### Pattern 12: Reading Page Content as Markdown
+Extract the main article content of a page as clean markdown. Uses Readability to identify the article body and converts it to LLM-friendly markdown with metadata (title, byline, excerpt, URL). Non-article pages (SPAs, dashboards) fall back to converting the full page.
+
+```bash
+# Read the current page as markdown (title prepended as H1)
+chrome-devtools --target warm-squid read-page
+
+# Save to a file
+chrome-devtools --target warm-squid read-page --output /tmp/article.md
+
+# JSON output includes metadata fields (title, byline, excerpt, site_name, url)
+chrome-devtools --target warm-squid read-page --json
+```
+
+**When to use `read-page` vs `snapshot`:**
+- `read-page` — you want the page's textual content as readable markdown (articles, docs, wiki pages). Best for summarization, extraction, or feeding content to an LLM.
+- `snapshot` — you need the full accessibility tree with element IDs, roles, and interactive elements. Best for understanding page structure and finding elements to click/fill.
+
 ## Complete Command Reference
 
 ### Navigation
@@ -312,6 +330,7 @@ chrome-devtools select-page [index_or_target_name]
 ```bash
 chrome-devtools --target <name> screenshot [--output <path>] [--full-page]
 chrome-devtools --target <name> snapshot
+chrome-devtools --target <name> read-page [--output <path>]
 chrome-devtools --target <name> evaluate "<js-expression>" [--dialog-action accept|dismiss|text]
 chrome-devtools --target <name> network [--duration <ms>] [--type <resource>]
 chrome-devtools --target <name> console [--duration <ms>] [--type <level>]

--- a/src/commands/executor.rs
+++ b/src/commands/executor.rs
@@ -45,6 +45,7 @@ pub fn known_args(cmd: &str) -> &'static [&'static str] {
         "press-key" => &["key"],
         "hover" => &["selector"],
         "snapshot" => &["output"],
+        "read-page" => &["output"],
         "emulate" => &[
             "viewport",
             "device_scale_factor",
@@ -424,6 +425,15 @@ async fn inner_execute(
         },
         "snapshot" => {
             commands::snapshot::take_snapshot(
+                client,
+                session_id,
+                req.format(),
+                args.get("output").and_then(|v| v.as_str()),
+            )
+            .await
+        }
+        "read-page" => {
+            commands::read_page::read_page(
                 client,
                 session_id,
                 req.format(),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod input;
 pub mod navigate;
 pub mod network;
 pub mod pages;
+pub mod read_page;
 pub mod screenshot;
 pub mod snapshot;
 pub mod sw_logs;

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -12,15 +12,25 @@ use crate::result::CommandResult;
 const GET_HTML_AND_URL_JS: &str =
     "JSON.stringify({html: document.documentElement.outerHTML, url: window.location.href})";
 
+/// Case-insensitive substring search without allocating a lowercase copy.
+fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    haystack
+        .as_bytes()
+        .windows(needle.len())
+        .position(|w| w.iter().zip(needle.bytes()).all(|(a, b)| a.to_ascii_lowercase() == b))
+}
+
 /// Extract the `<title>` text from raw HTML via case-insensitive string search.
 /// Used as a fallback when Readability doesn't produce a title.
 fn extract_title_from_html(html: &str) -> Option<String> {
-    let lower = html.to_ascii_lowercase();
     let open = "<title>";
     let close = "</title>";
 
-    let start = lower.find(open)? + open.len();
-    let end = lower[start..].find(close)? + start;
+    let start = find_ci(html, open)? + open.len();
+    let end = find_ci(&html[start..], close)? + start;
     let title = html[start..end].trim();
 
     if title.is_empty() {
@@ -33,13 +43,13 @@ fn extract_title_from_html(html: &str) -> Option<String> {
 /// Decode common HTML entities. `&amp;` is decoded last (via placeholder) to
 /// prevent double-decoding (e.g. `&amp;lt;` → `&lt;`, not `<`).
 fn decode_html_entities(s: &str) -> String {
-    let s = s.replace("&amp;", "\x00");
+    let s = s.replace("&amp;", "\u{E000}");
     let s = s.replace("&lt;", "<");
     let s = s.replace("&gt;", ">");
     let s = s.replace("&quot;", "\"");
     let s = s.replace("&#39;", "'");
     let s = s.replace("&apos;", "'");
-    s.replace("\x00", "&")
+    s.replace("\u{E000}", "&")
 }
 
 /// Run Mozilla-Readability-style extraction over `html`, returning the cleaned
@@ -119,25 +129,23 @@ struct ReadableMeta {
 fn unwrap_iframes(html: &str) -> String {
     let mut result = html.to_string();
     loop {
-        let lower = result.to_ascii_lowercase();
-
         // Find innermost iframe: an <iframe> with no nested <iframe> inside.
         let mut search_from = 0;
         let mut best_open = None;
         let mut best_close = None;
 
-        while let Some(open) = lower[search_from..].find("<iframe") {
+        while let Some(open) = find_ci(&result[search_from..], "<iframe") {
             let open = search_from + open;
             let tag_end = match result[open..].find('>') {
                 Some(i) => open + i + 1,
                 None => break,
             };
 
-            if let Some(close) = lower[tag_end..].find("</iframe") {
+            if let Some(close) = find_ci(&result[tag_end..], "</iframe") {
                 let close = tag_end + close;
-                let inner = &lower[tag_end..close];
+                let inner = &result[tag_end..close];
 
-                if !inner.contains("<iframe") {
+                if find_ci(inner, "<iframe").is_none() {
                     // Innermost — no nested <iframe> between open and close.
                     best_open = Some((open, tag_end));
                     best_close = Some(close);

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -20,17 +20,23 @@ fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
     haystack
         .as_bytes()
         .windows(needle.len())
-        .position(|w| w.iter().zip(needle.bytes()).all(|(a, b)| a.to_ascii_lowercase() == b))
+        .position(|w| {
+            w.iter()
+                .zip(needle.bytes())
+                .all(|(a, b)| a.to_ascii_lowercase() == b.to_ascii_lowercase())
+        })
 }
 
 /// Extract the `<title>` text from raw HTML via case-insensitive string search.
 /// Used as a fallback when Readability doesn't produce a title.
 fn extract_title_from_html(html: &str) -> Option<String> {
-    let open = "<title>";
-    let close = "</title>";
+    let open_tag = "<title";
+    let close_tag = "</title>";
 
-    let start = find_ci(html, open)? + open.len();
-    let end = find_ci(&html[start..], close)? + start;
+    let open_pos = find_ci(html, open_tag)?;
+    let tag_end = html[open_pos..].find('>')?;
+    let start = open_pos + tag_end + 1;
+    let end = find_ci(&html[start..], close_tag)? + start;
     let title = html[start..end].trim();
 
     if title.is_empty() {
@@ -43,13 +49,7 @@ fn extract_title_from_html(html: &str) -> Option<String> {
 /// Decode common HTML entities. `&amp;` is decoded last (via placeholder) to
 /// prevent double-decoding (e.g. `&amp;lt;` → `&lt;`, not `<`).
 fn decode_html_entities(s: &str) -> String {
-    let s = s.replace("&amp;", "\u{E000}");
-    let s = s.replace("&lt;", "<");
-    let s = s.replace("&gt;", ">");
-    let s = s.replace("&quot;", "\"");
-    let s = s.replace("&#39;", "'");
-    let s = s.replace("&apos;", "'");
-    s.replace("\u{E000}", "&")
+    html_escape::decode_html_entities(s).into_owned()
 }
 
 /// Run Mozilla-Readability-style extraction over `html`, returning the cleaned
@@ -162,7 +162,7 @@ fn unwrap_iframes(html: &str) -> String {
             result = format!("{}{}", &result[..open], &result[tag_end..]);
             best_open = None;
             best_close = None;
-            break;
+            continue;
         }
 
         match (best_open, best_close) {
@@ -452,6 +452,14 @@ mod tests {
         assert_eq!(
             unwrap_iframes("<p>A</p><iframe src=\"x\"><p>B</p>"),
             "<p>A</p><p>B</p>"
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_unclosed_followed_by_well_formed() {
+        assert_eq!(
+            unwrap_iframes("<iframe src=\"broken\"><iframe src=\"ok\"><p>B</p></iframe>"),
+            "<p>B</p>"
         );
     }
 

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -175,7 +175,7 @@ fn unwrap_iframes(html: &str) -> String {
                 let close_end = match result[close..].find('>') {
                     Some(i) => {
                         // Check if there's a '<' before the '>' to avoid crossing tag boundaries
-                        if result[close..close + i].contains('<') {
+                        if result[close + 1..close + i].contains('<') {
                             break;
                         }
                         close + i + 1

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -1,0 +1,696 @@
+use anyhow::Result;
+use dom_smoothie::{CandidateSelectMode, Config, Readability};
+use htmd::HtmlToMarkdown;
+use serde_json::{json, Value};
+
+use crate::cdp::CdpClient;
+use crate::format::{format_structured, OutputFormat};
+use crate::result::CommandResult;
+
+/// Inline JS that returns the page HTML and current URL in a single evaluation,
+/// avoiding a second CDP round trip for URL resolution.
+const GET_HTML_AND_URL_JS: &str =
+    "JSON.stringify({html: document.documentElement.outerHTML, url: window.location.href})";
+
+/// Extract the `<title>` text from raw HTML via case-insensitive string search.
+/// Used as a fallback when Readability doesn't produce a title.
+fn extract_title_from_html(html: &str) -> Option<String> {
+    let lower = html.to_ascii_lowercase();
+    let open = "<title>";
+    let close = "</title>";
+
+    let start = lower.find(open)? + open.len();
+    let end = lower[start..].find(close)? + start;
+    let title = html[start..end].trim();
+
+    if title.is_empty() {
+        None
+    } else {
+        Some(decode_html_entities(title))
+    }
+}
+
+/// Decode common HTML entities. `&amp;` is decoded last (via placeholder) to
+/// prevent double-decoding (e.g. `&amp;lt;` → `&lt;`, not `<`).
+fn decode_html_entities(s: &str) -> String {
+    let s = s.replace("&amp;", "\x00");
+    let s = s.replace("&lt;", "<");
+    let s = s.replace("&gt;", ">");
+    let s = s.replace("&quot;", "\"");
+    let s = s.replace("&#39;", "'");
+    let s = s.replace("&apos;", "'");
+    s.replace("\x00", "&")
+}
+
+/// Run Mozilla-Readability-style extraction over `html`, returning the cleaned
+/// article HTML plus its detected title. Falls back to the raw page HTML when
+/// the document is not article-like (apps, dashboards, search results) or when
+/// extraction fails, so we never silently drop content.
+fn extract_content(html: &str, url: Option<&str>) -> (String, ReadableMeta) {
+    let cfg = Config {
+        // DomSmoothie candidate selection captures more of the meaningful
+        // content than the stock Readability heuristic, which sometimes
+        // discards sections when there are few competing candidates.
+        candidate_select_mode: CandidateSelectMode::DomSmoothie,
+        ..Default::default()
+    };
+
+    let fallback_title = extract_title_from_html(html);
+
+    match Readability::new(html, url, Some(cfg)) {
+        Ok(mut r) if r.is_probably_readable() => match r.parse() {
+            Ok(article) => {
+                let title = if article.title.is_empty() {
+                    fallback_title
+                } else {
+                    Some(article.title.clone())
+                };
+                let meta = ReadableMeta {
+                    title,
+                    byline: article.byline.clone(),
+                    excerpt: article.excerpt.clone(),
+                    site_name: article.site_name.clone(),
+                };
+                (article.content.to_string(), meta)
+            }
+            // Readable but extraction failed: hand back the whole page.
+            Err(_) => (
+                html.to_string(),
+                ReadableMeta {
+                    title: fallback_title,
+                    byline: None,
+                    excerpt: None,
+                    site_name: None,
+                },
+            ),
+        },
+        // Not article-like, or the document couldn't be loaded: don't let
+        // readability mangle it — convert the full page instead.
+        _ => (
+            html.to_string(),
+            ReadableMeta {
+                title: fallback_title,
+                byline: None,
+                excerpt: None,
+                site_name: None,
+            },
+        ),
+    }
+}
+
+/// Metadata surfaced by readability, used to enrich text/structured output.
+struct ReadableMeta {
+    title: Option<String>,
+    byline: Option<String>,
+    excerpt: Option<String>,
+    site_name: Option<String>,
+}
+
+/// Unwrap `<iframe>` tags, promoting their inner HTML to the parent level.
+///
+/// `html5ever` (used by `htmd`) treats `<iframe>` as a raw-text element per the
+/// HTML spec, so inner HTML is stored as escaped text rather than parsed DOM.
+/// Pre-stripping the tags lets the inner content flow through as normal HTML
+/// for proper markdown conversion.
+///
+/// Processes innermost iframes first (an `<iframe>` whose content contains no
+/// nested `<iframe>`), preventing tag-mismatch on deeply nested cases. Loops
+/// until all iframes are unwrapped.
+fn unwrap_iframes(html: &str) -> String {
+    let mut result = html.to_string();
+    loop {
+        let lower = result.to_ascii_lowercase();
+
+        // Find innermost iframe: an <iframe> with no nested <iframe> inside.
+        let mut search_from = 0;
+        let mut best_open = None;
+        let mut best_close = None;
+
+        while let Some(open) = lower[search_from..].find("<iframe") {
+            let open = search_from + open;
+            let tag_end = match result[open..].find('>') {
+                Some(i) => open + i + 1,
+                None => break,
+            };
+
+            if let Some(close) = lower[tag_end..].find("</iframe") {
+                let close = tag_end + close;
+                let inner = &lower[tag_end..close];
+
+                if !inner.contains("<iframe") {
+                    // Innermost — no nested <iframe> between open and close.
+                    best_open = Some((open, tag_end));
+                    best_close = Some(close);
+                    break;
+                }
+
+                // Has nested <iframe> inside — advance past this open tag
+                // and look for the inner one.
+                search_from = tag_end;
+                continue;
+            }
+
+            // No closing tag found — strip the opening tag and retry.
+            result = format!("{}{}", &result[..open], &result[tag_end..]);
+            best_open = None;
+            best_close = None;
+            break;
+        }
+
+        match (best_open, best_close) {
+            (Some((open, tag_end)), Some(close)) => {
+                let close_end = match result[close..].find('>') {
+                    Some(i) => close + i + 1,
+                    None => break,
+                };
+                let inner = &result[tag_end..close];
+                result = format!("{}{}{}", &result[..open], inner, &result[close_end..]);
+            }
+            _ => break,
+        }
+    }
+    result
+}
+
+/// Convert HTML to markdown and format the output for display.
+///
+/// Only strips truly inert elements — scripts, styles, metadata, and visual-only
+/// tags (svg/canvas) that produce no useful markdown. Structural containers
+/// (nav, footer, aside) are preserved: they hold navigable links the LLM can
+/// act on. Iframe tags are unwrapped before conversion so their inner HTML is
+/// parsed and converted as normal content.
+fn format_output(
+    content_html: &str,
+    meta: &ReadableMeta,
+    url: Option<&str>,
+    format: OutputFormat,
+) -> Result<String> {
+    let preprocessed = unwrap_iframes(content_html);
+
+    let converter = HtmlToMarkdown::builder()
+        .skip_tags(vec![
+            "head", "script", "style", "noscript", "link", "meta", "title", "svg", "canvas",
+        ])
+        .build();
+    let body_md = converter.convert(&preprocessed)?;
+
+    if format.is_text() {
+        match &meta.title {
+            Some(t) if !t.is_empty() && !body_md.trim_start().starts_with("# ") => {
+                Ok(format!("# {}\n\n{}", t, body_md))
+            }
+            _ => Ok(body_md),
+        }
+    } else {
+        let mut obj = json!({ "markdown": body_md });
+        if let Some(t) = &meta.title {
+            obj["title"] = json!(t);
+        }
+        if let Some(b) = &meta.byline {
+            obj["byline"] = json!(b);
+        }
+        if let Some(e) = &meta.excerpt {
+            obj["excerpt"] = json!(e);
+        }
+        if let Some(s) = &meta.site_name {
+            obj["site_name"] = json!(s);
+        }
+        if let Some(u) = url {
+            obj["url"] = json!(u);
+        }
+        format_structured(&obj, format)
+    }
+}
+
+/// Read the current page as markdown.
+///
+/// Serializes the rendered DOM, extracts the main article with a Readability
+/// port (`dom_smoothie`), then converts the cleaned HTML to markdown via
+/// `htmd`. Non-article pages fall back to converting the full page so content
+/// is never silently dropped. Output is LLM-friendly by default.
+pub async fn read_page(
+    client: &mut CdpClient,
+    session_id: &str,
+    format: OutputFormat,
+    output: Option<&str>,
+) -> Result<CommandResult> {
+    // Single CDP call fetches both HTML and URL — avoids a second round trip
+    // that a separate `current_url()` call would require.
+    let result = client
+        .send_to_target(
+            session_id,
+            "Runtime.evaluate",
+            json!({
+                "expression": GET_HTML_AND_URL_JS,
+                "returnByValue": true,
+            }),
+        )
+        .await?;
+
+    if let Some(exception) = result.get("exceptionDetails") {
+        let text = exception["text"]
+            .as_str()
+            .or_else(|| exception["exception"]["description"].as_str())
+            .unwrap_or("Unknown error evaluating page content");
+        anyhow::bail!("{text}");
+    }
+
+    let raw = result["result"]["value"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Failed to read page content"))?;
+
+    let (html, url) = match serde_json::from_str::<Value>(raw) {
+        Ok(v) if v.is_object() => (
+            v["html"].as_str().unwrap_or("").to_string(),
+            v["url"].as_str().map(|s| s.to_string()),
+        ),
+        // Fallback: treat as plain HTML string (shouldn't happen with our JS).
+        _ => (raw.to_string(), None),
+    };
+
+    let (content_html, meta) = extract_content(&html, url.as_deref());
+    let content = format_output(&content_html, &meta, url.as_deref(), format)?;
+
+    Ok(CommandResult::output(content).save_output(output).await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    // -- extract_title_from_html --
+
+    #[test]
+    fn extract_title_normal() {
+        let html = "<html><head><title>My Page Title</title></head><body></body></html>";
+        assert_eq!(
+            extract_title_from_html(html),
+            Some("My Page Title".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_case_insensitive() {
+        let html = "<html><head><TITLE>Upper Title</TITLE></head></html>";
+        assert_eq!(
+            extract_title_from_html(html),
+            Some("Upper Title".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_missing() {
+        assert_eq!(extract_title_from_html("<html><body>Hello</body></html>"), None);
+    }
+
+    #[test]
+    fn extract_title_empty() {
+        assert_eq!(
+            extract_title_from_html("<html><head><title></title></head></html>"),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_title_whitespace_trimmed() {
+        let html = "<html><head><title>  Trimmed Title  </title></head></html>";
+        assert_eq!(
+            extract_title_from_html(html),
+            Some("Trimmed Title".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_decodes_html_entities() {
+        let html = "<html><head><title>Foo &amp; Bar</title></head></html>";
+        assert_eq!(
+            extract_title_from_html(html),
+            Some("Foo & Bar".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_decodes_multiple_entities() {
+        let html = "<html><head><title>&lt;script&gt; &quot;alert&quot;</title></head></html>";
+        assert_eq!(
+            extract_title_from_html(html),
+            Some("<script> \"alert\"".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_title_no_double_decode() {
+        // &amp;lt; should decode to &lt; (not <)
+        let html = "<html><head><title>&amp;lt;escaped&amp;gt;</title></head></html>";
+        assert_eq!(
+            extract_title_from_html(html),
+            Some("&lt;escaped&gt;".to_string())
+        );
+    }
+
+    // -- decode_html_entities --
+
+    #[test]
+    fn decode_entities_ampersand() {
+        assert_eq!(decode_html_entities("A &amp; B"), "A & B");
+    }
+
+    #[test]
+    fn decode_entities_all_named() {
+        assert_eq!(
+            decode_html_entities("&lt;&gt;&quot;&#39;&apos;&amp;"),
+            "<>\"''&"
+        );
+    }
+
+    #[test]
+    fn decode_entities_no_double_decode() {
+        assert_eq!(decode_html_entities("&amp;lt;"), "&lt;");
+    }
+
+    #[test]
+    fn decode_entities_plain_text_unchanged() {
+        assert_eq!(decode_html_entities("no entities here"), "no entities here");
+    }
+
+    // -- unwrap_iframes --
+
+    #[test]
+    fn unwrap_iframes_basic() {
+        assert_eq!(
+            unwrap_iframes("<p>A</p><iframe src=\"x\"><p>B</p></iframe><p>C</p>"),
+            "<p>A</p><p>B</p><p>C</p>"
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_preserves_attributes_in_inner_html() {
+        assert_eq!(
+            unwrap_iframes("<iframe src=\"x\"><a href=\"/link\">click</a></iframe>"),
+            "<a href=\"/link\">click</a>"
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_mixed_case() {
+        assert_eq!(
+            unwrap_iframes("<IFRAME src=\"x\"><P>Content</P></IFRAME>"),
+            "<P>Content</P>"
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_multiple_siblings() {
+        assert_eq!(
+            unwrap_iframes("<iframe src=\"a\">A</iframe><iframe src=\"b\">B</iframe>"),
+            "AB"
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_nested() {
+        assert_eq!(
+            unwrap_iframes("<iframe src=\"outer\">O<iframe src=\"inner\">I</iframe>O</iframe>"),
+            "OIO"
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_deeply_nested() {
+        assert_eq!(
+            unwrap_iframes(
+                "<iframe src=\"1\">A<iframe src=\"2\">B<iframe src=\"3\">C</iframe>B</iframe>A</iframe>"
+            ),
+            "ABCBA"
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_empty() {
+        assert_eq!(
+            unwrap_iframes("<iframe src=\"x\"></iframe>"),
+            ""
+        );
+    }
+
+    #[test]
+    fn unwrap_iframes_no_iframes() {
+        assert_eq!(unwrap_iframes("<p>plain html</p>"), "<p>plain html</p>");
+    }
+
+    #[test]
+    fn unwrap_iframes_unclosed_strips_open_tag() {
+        assert_eq!(
+            unwrap_iframes("<p>A</p><iframe src=\"x\"><p>B</p>"),
+            "<p>A</p><p>B</p>"
+        );
+    }
+
+    // -- extract_content --
+
+    #[test]
+    fn extract_content_non_article_returns_raw_html_with_title() {
+        let html = "<html><head><title>Login Page</title></head><body><h1>Log In</h1><form><input type='text'/></form></body></html>";
+        let (content, meta) = extract_content(html, None);
+        assert_eq!(content, html);
+        assert_eq!(meta.title, Some("Login Page".to_string()));
+        assert!(meta.byline.is_none());
+        assert!(meta.excerpt.is_none());
+        assert!(meta.site_name.is_none());
+    }
+
+    #[test]
+    fn extract_content_no_title_anywhere() {
+        let html = "<html><body><p>Just some content with no title tag.</p></body></html>";
+        let (content, meta) = extract_content(html, None);
+        assert_eq!(content, html);
+        assert!(meta.title.is_none());
+    }
+
+    #[test]
+    fn extract_content_passes_url_for_relative_link_resolution() {
+        let html = "<html><head><title>Test</title></head><body><a href='/page'>link</a></body></html>";
+        let url = "https://example.com/article";
+        let (_, _) = extract_content(html, Some(url));
+        // Smoke test: URL is accepted without panic. Readability may or may not
+        // use it depending on whether the page is deemed article-like.
+    }
+
+    #[test]
+    fn extract_content_readability_article() {
+        // Enough content to pass Readability's is_probably_readable() threshold.
+        let html = r#"<html><head><title>Readability Test</title></head><body>
+            <article>
+                <h1>Article Heading</h1>
+                <p>This is the first paragraph of a test article. It contains enough text to be
+                considered substantial by the Readability algorithm which typically requires
+                paragraphs of reasonable length to score well.</p>
+                <p>The second paragraph adds more weight to the article scoring algorithm.
+                Readability uses text density, paragraph count, and other signals to determine
+                whether a page is article-like.</p>
+                <p>A third paragraph for good measure ensures the content density is high enough
+                to trigger the readability detection. Without sufficient text the algorithm
+                would classify this as a non-article page.</p>
+                <p>The fourth paragraph further strengthens the article signal. Real articles
+                typically have multiple paragraphs of substantive text which is what the
+                algorithm is designed to detect.</p>
+                <p>A fifth paragraph makes this unambiguously article-like content. The
+                Readability algorithm should have no trouble identifying this as an article
+                worth extracting.</p>
+            </article>
+        </body></html>"#;
+        let (content, meta) = extract_content(html, None);
+        // Should extract article content (not return raw HTML).
+        assert_ne!(content, html);
+        assert!(content.contains("first paragraph"));
+        // Title should come from Readability, falling back to <title> tag.
+        assert!(meta.title.is_some());
+    }
+
+    // -- format_output --
+
+    #[test]
+    fn format_output_text_prepends_title_as_h1() {
+        let html = "<p>Hello world</p>";
+        let meta = ReadableMeta {
+            title: Some("My Article".to_string()),
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert!(result.starts_with("# My Article\n\n"));
+    }
+
+    #[test]
+    fn format_output_text_no_double_h1_when_body_starts_with_heading() {
+        let html = "<h1>Already Has Heading</h1><p>Content here</p>";
+        let meta = ReadableMeta {
+            title: Some("Duplicate Title".to_string()),
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        // Should NOT prepend "# Duplicate Title" since body starts with "# "
+        assert!(!result.starts_with("# Duplicate Title\n\n# Already"));
+    }
+
+    #[test]
+    fn format_output_text_no_title_no_prepend() {
+        let html = "<p>Just content</p>";
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert!(!result.starts_with("# "));
+    }
+
+    #[test]
+    fn format_output_structured_no_nulls_for_missing_metadata() {
+        let html = "<p>Hello world</p>";
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Json).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed.get("markdown").is_some());
+        assert!(parsed.get("title").is_none());
+        assert!(parsed.get("byline").is_none());
+        assert!(parsed.get("excerpt").is_none());
+        assert!(parsed.get("site_name").is_none());
+    }
+
+    #[test]
+    fn format_output_structured_includes_url() {
+        let html = "<p>Content</p>";
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(
+            html,
+            &meta,
+            Some("https://example.com"),
+            OutputFormat::Json,
+        )
+        .unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["url"], "https://example.com");
+    }
+
+    #[test]
+    fn format_output_structured_includes_present_metadata() {
+        let html = "<p>Content</p>";
+        let meta = ReadableMeta {
+            title: Some("Article".to_string()),
+            byline: Some("Jane Doe".to_string()),
+            excerpt: None,
+            site_name: Some("Example".to_string()),
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Json).unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["title"], "Article");
+        assert_eq!(parsed["byline"], "Jane Doe");
+        assert_eq!(parsed["site_name"], "Example");
+        // excerpt is None → must not appear
+        assert!(parsed.get("excerpt").is_none());
+    }
+
+    #[test]
+    fn format_output_skip_tags_strips_scripts_and_styles() {
+        let html =
+            "<head><style>body{color:red}</style></head><script>alert(1)</script><p>Real content</p>";
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert!(!result.contains("color:red"));
+        assert!(!result.contains("alert"));
+        assert!(result.contains("Real content"));
+    }
+
+    #[test]
+    fn format_output_preserves_nav_footer_aside() {
+        let html = "<nav>Navigation</nav><main><p>Main content</p></main><footer>Footer</footer><aside>Sidebar</aside>";
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert!(result.contains("Navigation"));
+        assert!(result.contains("Main content"));
+        assert!(result.contains("Footer"));
+        assert!(result.contains("Sidebar"));
+    }
+
+    #[test]
+    fn format_output_preserves_form_elements() {
+        let html = "<form><button>Submit</button><select><option>A</option></select></form>";
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert!(result.contains("Submit"));
+    }
+
+    #[test]
+    fn format_output_recursively_converts_iframe_inner_content() {
+        let html = r#"<p>Before</p><iframe src="https://example.com"><p>Embedded <strong>bold</strong> text</p><a href="/link">A link</a></iframe><p>After</p>"#;
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert!(result.contains("Embedded **bold** text"));
+        assert!(result.contains("[A link](/link)"));
+        assert!(result.contains("Before"));
+        assert!(result.contains("After"));
+    }
+
+    #[test]
+    fn format_output_recursively_converts_nested_iframes() {
+        let html = r#"<iframe src="/outer"><p>Outer</p><iframe src="/inner"><p>Inner content</p></iframe></iframe>"#;
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert!(result.contains("Outer"));
+        assert!(result.contains("Inner content"));
+    }
+
+    #[test]
+    fn format_output_empty_iframe_produces_no_output() {
+        let html = "<p>Before</p><iframe src=\"https://example.com\"></iframe><p>After</p>";
+        let meta = ReadableMeta {
+            title: None,
+            byline: None,
+            excerpt: None,
+            site_name: None,
+        };
+        let result = format_output(html, &meta, None, OutputFormat::Text).unwrap();
+        assert_eq!(result.trim(), "Before\n\nAfter");
+    }
+}

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -10,7 +10,7 @@ use crate::result::CommandResult;
 /// Inline JS that returns the page HTML and current URL in a single evaluation,
 /// avoiding a second CDP round trip for URL resolution.
 const GET_HTML_AND_URL_JS: &str =
-    "JSON.stringify({html: document.documentElement.outerHTML, url: window.location.href})";
+    "JSON.stringify({html: document.documentElement ? document.documentElement.outerHTML : '', url: window.location.href})";
 
 /// Case-insensitive substring search without allocating a lowercase copy.
 fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
@@ -28,6 +28,20 @@ fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
         })
 }
 
+fn find_tag_end(s: &str) -> Option<usize> {
+    let mut in_double_quote = false;
+    let mut in_single_quote = false;
+    for (idx, b) in s.bytes().enumerate() {
+        match b {
+            b'"' if !in_single_quote => in_double_quote = !in_double_quote,
+            b'\'' if !in_double_quote => in_single_quote = !in_single_quote,
+            b'>' if !in_double_quote && !in_single_quote => return Some(idx),
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Extract the `<title>` text from raw HTML via case-insensitive string search.
 /// Used as a fallback when Readability doesn't produce a title.
 fn extract_title_from_html(html: &str) -> Option<String> {
@@ -35,7 +49,7 @@ fn extract_title_from_html(html: &str) -> Option<String> {
     let close_tag = "</title>";
 
     let open_pos = find_ci(html, open_tag)?;
-    let tag_end = html[open_pos..].find('>')?;
+    let tag_end = find_tag_end(&html[open_pos..])?;
     let start = open_pos + tag_end + 1;
     let end = find_ci(&html[start..], close_tag)? + start;
     let title = html[start..end].trim();
@@ -136,7 +150,7 @@ fn unwrap_iframes(html: &str) -> String {
 
         while let Some(open) = find_ci(&result[search_from..], "<iframe") {
             let open = search_from + open;
-            let tag_end = match result[open..].find('>') {
+            let tag_end = match find_tag_end(&result[open..]) {
                 Some(i) => open + i + 1,
                 None => {
                     // Malformed tag: no closing '>' found. Skip past this '<' and continue
@@ -172,7 +186,7 @@ fn unwrap_iframes(html: &str) -> String {
 
         match (best_open, best_close) {
             (Some((open, tag_end)), Some(close)) => {
-                let close_end = match result[close..].find('>') {
+                let close_end = match find_tag_end(&result[close..]) {
                     Some(i) => {
                         // Check if there's a '<' before the '>' to avoid crossing tag boundaries
                         if result[close + 1..close + i].contains('<') {

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -17,12 +17,13 @@ fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
     if needle.is_empty() {
         return Some(0);
     }
+    let needle_bytes = needle.as_bytes();
     haystack
         .as_bytes()
-        .windows(needle.len())
+        .windows(needle_bytes.len())
         .position(|w| {
             w.iter()
-                .zip(needle.bytes())
+                .zip(needle_bytes)
                 .all(|(a, b)| a.to_ascii_lowercase() == b.to_ascii_lowercase())
         })
 }
@@ -46,8 +47,7 @@ fn extract_title_from_html(html: &str) -> Option<String> {
     }
 }
 
-/// Decode common HTML entities. `&amp;` is decoded last (via placeholder) to
-/// prevent double-decoding (e.g. `&amp;lt;` → `&lt;`, not `<`).
+/// Decode common HTML entities.
 fn decode_html_entities(s: &str) -> String {
     html_escape::decode_html_entities(s).into_owned()
 }
@@ -173,7 +173,13 @@ fn unwrap_iframes(html: &str) -> String {
         match (best_open, best_close) {
             (Some((open, tag_end)), Some(close)) => {
                 let close_end = match result[close..].find('>') {
-                    Some(i) => close + i + 1,
+                    Some(i) => {
+                        // Check if there's a '<' before the '>' to avoid crossing tag boundaries
+                        if result[close..close + i].contains('<') {
+                            break;
+                        }
+                        close + i + 1
+                    }
                     None => break,
                 };
                 let inner = &result[tag_end..close];

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -138,7 +138,12 @@ fn unwrap_iframes(html: &str) -> String {
             let open = search_from + open;
             let tag_end = match result[open..].find('>') {
                 Some(i) => open + i + 1,
-                None => break,
+                None => {
+                    // Malformed tag: no closing '>' found. Skip past this '<' and continue
+                    // searching for the next potential tag.
+                    search_from = open + 1;
+                    continue;
+                }
             };
 
             if let Some(close) = find_ci(&result[tag_end..], "</iframe") {

--- a/src/commands/read_page.rs
+++ b/src/commands/read_page.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use dom_smoothie::{CandidateSelectMode, Config, Readability};
 use htmd::HtmlToMarkdown;
-use serde_json::{json, Value};
+use serde_json::json;
 
 use crate::cdp::CdpClient;
 use crate::format::{format_structured, OutputFormat};
@@ -10,7 +10,7 @@ use crate::result::CommandResult;
 /// Inline JS that returns the page HTML and current URL in a single evaluation,
 /// avoiding a second CDP round trip for URL resolution.
 const GET_HTML_AND_URL_JS: &str =
-    "JSON.stringify({html: document.documentElement ? document.documentElement.outerHTML : '', url: window.location.href})";
+    "({html: document.documentElement ? document.documentElement.outerHTML : '', url: window.location.href})";
 
 /// Case-insensitive substring search without allocating a lowercase copy.
 fn find_ci(haystack: &str, needle: &str) -> Option<usize> {
@@ -288,18 +288,13 @@ pub async fn read_page(
         anyhow::bail!("{text}");
     }
 
-    let raw = result["result"]["value"]
-        .as_str()
-        .ok_or_else(|| anyhow::anyhow!("Failed to read page content"))?;
+    let val = &result["result"]["value"];
+    if val.is_null() {
+        anyhow::bail!("Failed to read page content");
+    }
 
-    let (html, url) = match serde_json::from_str::<Value>(raw) {
-        Ok(v) if v.is_object() => (
-            v["html"].as_str().unwrap_or("").to_string(),
-            v["url"].as_str().map(|s| s.to_string()),
-        ),
-        // Fallback: treat as plain HTML string (shouldn't happen with our JS).
-        _ => (raw.to_string(), None),
-    };
+    let html = val["html"].as_str().unwrap_or("").to_string();
+    let url = val["url"].as_str().map(|s| s.to_string());
 
     let (content_html, meta) = extract_content(&html, url.as_deref());
     let content = format_output(&content_html, &meta, url.as_deref(), format)?;

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -132,9 +132,7 @@ pub async fn list_3p_tools(
                                     .as_object()
                                     .map(|obj| {
                                         obj.iter()
-                                            .filter_map(|(k, v)| {
-                                                Some(format!("{}={}", k, v))
-                                            })
+                                            .map(|(k, v)| format!("{}={}", k, v))
                                             .collect()
                                     })
                                     .unwrap_or_default();

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -183,7 +183,7 @@ pub async fn execute_3p_tool(
                 const tools = await document.modelContext.getTools();
                 const tool = tools.find(t => t.name === {safe_name_json});
                 if (tool) {{
-                    const result = await document.modelContext.executeTool(tool, {safe_params_json});
+                    const result = await document.modelContext.executeTool(tool, params);
                     return JSON.stringify({{ api: 'modelContext', result }});
                 }}
             }} catch (e) {{

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -27,7 +27,7 @@ pub async fn list_3p_tools(
                         origin: t.origin || null
                     }))
                 })
-            }));
+            })).catch(e => JSON.stringify({ error: e.message || String(e) }));
         }
         const dtmcp = window.__dtmcp;
         if (!dtmcp) {
@@ -80,11 +80,14 @@ pub async fn list_3p_tools(
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Failed to list third-party tools"))?;
 
+    let val: serde_json::Value = serde_json::from_str(val_str)?;
+    if let Some(err) = val.get("error").and_then(|v| v.as_str()) {
+        bail!("Failed to list tools: {err}");
+    }
+
     if !format.is_text() {
-        let val: serde_json::Value = serde_json::from_str(val_str)?;
         Ok(CommandResult::output(format_structured(&val, format)?))
     } else {
-        let val: serde_json::Value = serde_json::from_str(val_str)?;
         let api = val["api"].as_str().unwrap_or("none");
         let groups = val["groups"]
             .as_array()

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -107,6 +107,7 @@ pub async fn list_3p_tools(
         let api_label = match api {
             "modelContext" => "WebMCP",
             "dtmcp" => "DTMCP (legacy)",
+            "none" => "None",
             _ => "unknown",
         };
 

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -26,7 +26,7 @@ pub async fn list_3p_tools(
                         annotations: t.annotations || null,
                         origin: t.origin || null
                     }))
-                })
+                }]
             })).catch(e => JSON.stringify({ error: e.message || String(e) }));
         }
         const dtmcp = window.__dtmcp;

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -76,6 +76,14 @@ pub async fn list_3p_tools(
         )
         .await?;
 
+    if let Some(exception) = result.get("exceptionDetails") {
+        let text = exception["text"]
+            .as_str()
+            .or_else(|| exception["exception"]["description"].as_str())
+            .unwrap_or("Unknown error evaluating third-party tools");
+        anyhow::bail!("{text}");
+    }
+
     let val_str = result["result"]["value"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Failed to list third-party tools"))?;
@@ -225,6 +233,14 @@ pub async fn execute_3p_tool(
             json!({"expression": expr, "returnByValue": true, "awaitPromise": true}),
         )
         .await?;
+
+    if let Some(exception) = result.get("exceptionDetails") {
+        let text = exception["text"]
+            .as_str()
+            .or_else(|| exception["exception"]["description"].as_str())
+            .unwrap_or("Unknown error executing third-party tool");
+        anyhow::bail!("{text}");
+    }
 
     let val_str = result["result"]["value"]
         .as_str()

--- a/src/commands/third_party.rs
+++ b/src/commands/third_party.rs
@@ -5,51 +5,74 @@ use crate::cdp::CdpClient;
 use crate::format::{format_structured, OutputFormat};
 use crate::result::CommandResult;
 
-/// List third-party DevTools tools registered via __dtmcp on the page.
+/// List third-party DevTools tools via WebMCP (`document.modelContext`) or
+/// the legacy `__dtmcp` global. WebMCP is preferred when available.
 pub async fn list_3p_tools(
     client: &mut CdpClient,
     session_id: &str,
     format: OutputFormat,
 ) -> Result<CommandResult> {
     let expr = r#"(() => {
+        if (document.modelContext && typeof document.modelContext.getTools === 'function') {
+            return document.modelContext.getTools().then(tools => JSON.stringify({
+                api: 'modelContext',
+                groups: [{
+                    name: 'WebMCP',
+                    description: 'Tools exposed via the WebMCP API',
+                    tools: tools.map(t => ({
+                        name: t.name,
+                        description: t.description,
+                        inputSchema: t.inputSchema,
+                        annotations: t.annotations || null,
+                        origin: t.origin || null
+                    }))
+                })
+            }));
+        }
         const dtmcp = window.__dtmcp;
         if (!dtmcp) {
-            return JSON.stringify({ groups: [] });
+            return JSON.stringify({ api: 'none', groups: [] });
         }
         if (Array.isArray(dtmcp.toolGroups) && dtmcp.toolGroups.length > 0) {
             return JSON.stringify({
+                api: 'dtmcp',
                 groups: dtmcp.toolGroups.map(g => ({
                     name: g.name,
                     description: g.description,
                     tools: (g.tools || []).map(t => ({
                         name: t.name,
                         description: t.description,
-                        inputSchema: t.inputSchema
+                        inputSchema: t.inputSchema,
+                        annotations: null,
+                        origin: null
                     }))
                 }))
             });
         }
         if (dtmcp.toolGroup) {
             return JSON.stringify({
+                api: 'dtmcp',
                 groups: [{
                     name: dtmcp.toolGroup.name,
                     description: dtmcp.toolGroup.description,
                     tools: (dtmcp.toolGroup.tools || []).map(t => ({
                         name: t.name,
                         description: t.description,
-                        inputSchema: t.inputSchema
+                        inputSchema: t.inputSchema,
+                        annotations: null,
+                        origin: null
                     }))
                 }]
             });
         }
-        return JSON.stringify({ groups: [] });
+        return JSON.stringify({ api: 'none', groups: [] });
     })()"#;
 
     let result = client
         .send_to_target(
             session_id,
             "Runtime.evaluate",
-            json!({"expression": expr, "returnByValue": true}),
+            json!({"expression": expr, "returnByValue": true, "awaitPromise": true}),
         )
         .await?;
 
@@ -62,6 +85,7 @@ pub async fn list_3p_tools(
         Ok(CommandResult::output(format_structured(&val, format)?))
     } else {
         let val: serde_json::Value = serde_json::from_str(val_str)?;
+        let api = val["api"].as_str().unwrap_or("none");
         let groups = val["groups"]
             .as_array()
             .ok_or_else(|| anyhow::anyhow!("Invalid response from page"))?;
@@ -77,7 +101,13 @@ pub async fn list_3p_tools(
             ));
         }
 
-        let mut output = String::new();
+        let api_label = match api {
+            "modelContext" => "WebMCP",
+            "dtmcp" => "DTMCP (legacy)",
+            _ => "unknown",
+        };
+
+        let mut output = format!("API: {}\n", api_label);
         for (i, group) in groups.iter().enumerate() {
             if i > 0 {
                 output.push('\n');
@@ -91,7 +121,31 @@ pub async fn list_3p_tools(
                     for tool in tools {
                         let tname = tool["name"].as_str().unwrap_or("unknown");
                         let tdesc = tool["description"].as_str().unwrap_or("");
-                        output.push_str(&format!("  - {}: {}\n", tname, tdesc));
+                        output.push_str(&format!("  - {}: {}", tname, tdesc));
+                        if let Some(origin) = tool["origin"].as_str() {
+                            output.push_str(&format!(" [origin: {}]", origin));
+                        }
+                        output.push('\n');
+                        if let Some(ann) = tool.get("annotations") {
+                            if !ann.is_null() {
+                                let parts: Vec<String> = ann
+                                    .as_object()
+                                    .map(|obj| {
+                                        obj.iter()
+                                            .filter_map(|(k, v)| {
+                                                Some(format!("{}={}", k, v))
+                                            })
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
+                                if !parts.is_empty() {
+                                    output.push_str(&format!(
+                                        "    annotations: {}\n",
+                                        parts.join(", ")
+                                    ));
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -101,7 +155,7 @@ pub async fn list_3p_tools(
     }
 }
 
-/// Execute a named third-party DevTools tool with optional JSON parameters.
+/// Execute a named third-party DevTools tool via WebMCP or legacy `__dtmcp`.
 pub async fn execute_3p_tool(
     client: &mut CdpClient,
     session_id: &str,
@@ -120,22 +174,39 @@ pub async fn execute_3p_tool(
 
     let expr = format!(
         r#"(async () => {{
+        const params = {safe_params_json};
+        let hasModelContext = false;
+        if (document.modelContext && typeof document.modelContext.getTools === 'function') {{
+            hasModelContext = true;
+            try {{
+                const tools = await document.modelContext.getTools();
+                const tool = tools.find(t => t.name === {safe_name_json});
+                if (tool) {{
+                    const result = await document.modelContext.executeTool(tool, {safe_params_json});
+                    return JSON.stringify({{ api: 'modelContext', result }});
+                }}
+            }} catch (e) {{
+                return JSON.stringify({{ error: e.message || String(e) }});
+            }}
+        }}
         const dtmcp = window.__dtmcp;
         if (!dtmcp) {{
-            return JSON.stringify({{ error: 'Third-party tools not supported on this page' }});
+            const msg = hasModelContext
+                ? 'Tool ' + {safe_name_json} + ' not found via WebMCP'
+                : 'No third-party tools API available on this page';
+            return JSON.stringify({{ error: msg }});
         }}
         try {{
-            const params = {safe_params_json};
             if (dtmcp.executeTool) {{
                 const result = await dtmcp.executeTool({safe_name_json}, params);
-                return JSON.stringify({{ result }});
+                return JSON.stringify({{ api: 'dtmcp', result }});
             }}
             const groups = dtmcp.toolGroups || (dtmcp.toolGroup ? [dtmcp.toolGroup] : []);
             for (const group of groups) {{
                 const tool = (group.tools || []).find(t => t.name === {safe_name_json});
                 if (tool && typeof tool.execute === 'function') {{
                     const result = await tool.execute(params);
-                    return JSON.stringify({{ result }});
+                    return JSON.stringify({{ api: 'dtmcp', result }});
                 }}
             }}
             return JSON.stringify({{ error: 'Tool ' + {safe_name_json} + ' not found' }});
@@ -168,9 +239,16 @@ pub async fn execute_3p_tool(
             format,
         )?))
     } else {
+        let api = val["api"].as_str().unwrap_or("unknown");
+        let api_label = match api {
+            "modelContext" => "WebMCP",
+            "dtmcp" => "DTMCP (legacy)",
+            _ => "unknown",
+        };
         Ok(CommandResult::output(format!(
-            "Successfully executed tool '{}'. Result:\n{}",
+            "Executed '{}' via {}:\n{}",
             name,
+            api_label,
             serde_json::to_string_pretty(&val["result"])?
         )))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,6 +204,14 @@ pub enum Commands {
         output: Option<String>,
     },
 
+    /// Read the current page as clean markdown (extracts the main article)
+    #[command(name = "read-page")]
+    ReadPage {
+        /// Write output to a file instead of stdout
+        #[arg(long, short)]
+        output: Option<String>,
+    },
+
     /// Manage page emulation (viewport, geolocation, etc.)
     Emulate {
         /// Set viewport size as WxH (e.g. 1280x720)
@@ -327,6 +335,7 @@ impl Cli {
             Commands::PressKey { .. } => "press-key",
             Commands::Hover { .. } => "hover",
             Commands::Snapshot { .. } => "snapshot",
+            Commands::ReadPage { .. } => "read-page",
             Commands::Emulate { .. } => "emulate",
             Commands::WaitFor { .. } => "wait-for",
             Commands::List3pTools => "list-3p-tools",
@@ -427,6 +436,7 @@ fn build_request(cli: &Cli) -> DaemonRequest {
         Commands::PressKey { key } => ("press-key", json!({"key": key})),
         Commands::Hover { selector } => ("hover", json!({"selector": selector})),
         Commands::Snapshot { output } => ("snapshot", json!({"output": output})),
+        Commands::ReadPage { output } => ("read-page", json!({"output": output})),
         Commands::Emulate {
             viewport,
             device_scale_factor,
@@ -902,6 +912,15 @@ async fn run_direct(cli: &Cli, ws_url: &str) -> Result<result::CommandResult> {
         }
         Commands::Snapshot { output } => {
             commands::snapshot::take_snapshot(
+                &mut client,
+                &session_id,
+                cli.output_format(),
+                output.as_deref(),
+            )
+            .await
+        }
+        Commands::ReadPage { output } => {
+            commands::read_page::read_page(
                 &mut client,
                 &session_id,
                 cli.output_format(),

--- a/wiki/read-page.md
+++ b/wiki/read-page.md
@@ -1,0 +1,141 @@
+# read-page
+
+Extract the current page's main content as clean markdown.
+
+## Synopsis
+
+```bash
+chrome-devtools [--target <name>] read-page [--output <path>]
+```
+
+## Description
+
+`read-page` serializes the rendered DOM, extracts the main article using a
+Readability algorithm (via [dom_smoothie](https://crates.io/crates/dom_smoothie)),
+then converts the cleaned HTML to markdown (via [htmd](https://crates.io/crates/htmd)).
+
+Non-article pages (SPAs, dashboards, search results) fall back to converting the
+full page, so content is never silently dropped.
+
+## Output
+
+### Text mode (default)
+
+Returns the article content as markdown with the page title prepended as an H1
+heading (unless the body already starts with one).
+
+```
+# Will Serfort
+
+**Will Serfort** is the protagonist of *Wistoria: Wand and Sword*...
+
+## Appearance
+
+Will has purple/blue eyes and messy black hair...
+```
+
+### JSON mode (`--json`)
+
+Returns a JSON object with the markdown body and any metadata extracted by
+Readability:
+
+```json
+{
+  "markdown": "**Will Serfort** is the protagonist...",
+  "title": "Will Serfort",
+  "byline": null,
+  "excerpt": "Will Serfort is the protagonist of...",
+  "site_name": null,
+  "url": "https://wistoria.fandom.com/wiki/Will_Serfort"
+}
+```
+
+Fields that are not available are omitted (not emitted as `null`).
+
+### TOON mode (`--toon`)
+
+Same fields as JSON in compact TOON encoding.
+
+## Pipeline
+
+```
+CDP Runtime.evaluate (HTML + URL as JSON)
+  → dom_smoothie Readability extraction
+    → unwrap <iframe> tags (innermost-first for nested support)
+      → htmd HTML→Markdown (skip inert elements only)
+        → format output (text with H1, or structured with metadata)
+```
+
+### Content extraction
+
+Uses `dom_smoothie` (a Rust port of Mozilla Readability) with DomSmoothie
+candidate selection, which captures more meaningful content than the stock
+Readability heuristic on pages with few competing candidates.
+
+### Title resolution
+
+1. Readability extracts a title from meta tags or headings
+2. Falls back to the `<title>` tag (with HTML entity decoding)
+3. If neither produces a title, no H1 is prepended
+
+### Inert element stripping
+
+Only truly inert elements are stripped:
+
+| Stripped | Reason |
+|----------|--------|
+| `head` | Document metadata container |
+| `script` | Executable code, no visible content |
+| `style` | CSS rules, no visible content |
+| `noscript` | Fallback for disabled JS |
+| `link` | External resource references |
+| `meta` | Document metadata |
+| `title` | Already captured by Readability |
+| `svg` | Visual-only, no markdown equivalent |
+| `canvas` | Pixel graphics, empty in serialized DOM |
+
+Structural containers (`nav`, `footer`, `aside`) and interactive elements
+(`form`, `button`, `select`) are **preserved** — they contain navigable links
+and actionable elements the LLM can interact with.
+
+### Iframe handling
+
+`<iframe>` tags are unwrapped before conversion, promoting their inner HTML to
+the parent level. This works around `html5ever` treating `<iframe>` as a
+raw-text element per the HTML spec (inner HTML stored as escaped text, not
+parsed DOM). Nested iframes are processed innermost-first to prevent tag
+mismatch.
+
+## When to use `read-page` vs `snapshot`
+
+| Use case | Command |
+|----------|---------|
+| Read article/docs content | `read-page` |
+| Feed page text to an LLM | `read-page` |
+| Extract structured metadata (title, author) | `read-page --json` |
+| Understand page structure | `snapshot` |
+| Find elements to click/fill | `snapshot` |
+| Get element IDs and roles | `snapshot` |
+
+## Examples
+
+```bash
+# Read a wiki article
+chrome-devtools --target warm-squid navigate https://en.wikipedia.org/wiki/Rust_(programming_language)
+chrome-devtools --target warm-squid read-page
+
+# Save to file
+chrome-devtools --target warm-squid read-page --output /tmp/article.md
+
+# Get metadata as JSON
+chrome-devtools --target warm-squid read-page --json
+
+# Read a non-article page (falls back to full-page conversion)
+chrome-devtools --target warm-squid navigate https://github.com
+chrome-devtools --target warm-squid read-page
+```
+
+## Dependencies
+
+- [dom_smoothie](https://crates.io/crates/dom_smoothie) — Rust port of Mozilla Readability
+- [htmd](https://crates.io/crates/htmd) — HTML to Markdown converter

--- a/wiki/read-page.md
+++ b/wiki/read-page.md
@@ -24,7 +24,7 @@ full page, so content is never silently dropped.
 Returns the article content as markdown with the page title prepended as an H1
 heading (unless the body already starts with one).
 
-```
+```md
 # Will Serfort
 
 **Will Serfort** is the protagonist of *Wistoria: Wand and Sword*...
@@ -43,9 +43,7 @@ Readability:
 {
   "markdown": "**Will Serfort** is the protagonist...",
   "title": "Will Serfort",
-  "byline": null,
   "excerpt": "Will Serfort is the protagonist of...",
-  "site_name": null,
   "url": "https://wistoria.fandom.com/wiki/Will_Serfort"
 }
 ```
@@ -58,7 +56,7 @@ Same fields as JSON in compact TOON encoding.
 
 ## Pipeline
 
-```
+```text
 CDP Runtime.evaluate (HTML + URL as JSON)
   → dom_smoothie Readability extraction
     → unwrap <iframe> tags (innermost-first for nested support)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `read-page` command to extract main page/article content, convert it to clean Markdown, and optionally write output to a file (including title/metadata with non-article fallback behavior).
  * Enhanced third-party tool discovery and execution to prefer WebMCP, with automatic legacy fallback and clearer API-labeled output.
* **Tests**
  * Added unit tests covering title/entity handling, iframe unwrapping, readability vs fallback behavior, and output formatting rules.
* **Documentation**
  * Updated README, agent guide, skill docs, and added a `read-page` wiki page with usage and guidance.
* **Chores**
  * Added new HTML/DOM conversion and entity-decoding dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->