### PR TITLE
fix: gate socket_path() with #[cfg(unix)] to fix Windows compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,6 +561,7 @@ pub async fn run() -> Result<()> {
     // Handle kill-daemon without connecting to Chrome
     if matches!(cli.command, Commands::KillDaemon) {
         let pid_path = protocol::pid_path();
+        #[cfg(unix)]
         let sock_path = protocol::socket_path();
         match std::fs::read_to_string(&pid_path) {
             Ok(pid_str) => {


### PR DESCRIPTION
Fixes #11

## Summary / 修复摘要

**English:**
Add #[cfg(unix)] to the sock_path variable declaration in src/lib.rs:564. The protocol::socket_path() function is only defined under #[cfg(unix)] in protocol.rs, but was called unconditionally, causing compilation to fail on Windows with E0425.

The variable is only used within the existing #[cfg(unix)] block for Unix signal-based daemon termination, so this is a safe, minimal fix.

**中文：**
在 src/lib.rs:564 的 sock_path 变量声明前加上 #[cfg(unix)]。protocol::socket_path() 函数在 protocol.rs 中仅在 #[cfg(unix)] 条件下定义，但被无条件调用，导致 Windows 下编译失败（错误码 E0425）。

该变量仅在已有的 #[cfg(unix)] 代码块中使用（Unix 信号方式的守护进程终止），因此这是一个安全、最小化的修复。

## Test / 测试

All 92 tests pass on Windows 11 with cargo test --all-targets.